### PR TITLE
Make paths configurable in scripts

### DIFF
--- a/De0_A1_Process_Fastq.4_SeqKit.sh
+++ b/De0_A1_Process_Fastq.4_SeqKit.sh
@@ -7,9 +7,21 @@ then
     exit 1
 fi
 
-# Definir los directorios de entrada y salida
-INPUT_DIR="/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock"
-OUTPUT_DIR="/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed"
+# Uso:
+#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./De0_A1_Process_Fastq.4_SeqKit.sh
+#   o bien
+#   ./De0_A1_Process_Fastq.4_SeqKit.sh /ruta/a/fastq /ruta/a/salida
+
+# Directorios de entrada y salida configurables por variables o argumentos
+INPUT_DIR="${INPUT_DIR:-$1}"
+OUTPUT_DIR="${OUTPUT_DIR:-$2}"
+
+# Comprobar que se proporcionaron las rutas
+if [ -z "$INPUT_DIR" ] || [ -z "$OUTPUT_DIR" ]; then
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0"
+    echo "   o: $0 <dir entrada> <dir salida>"
+    exit 1
+fi
 
 # Verificar si los directorios existen
 if [ ! -d "$INPUT_DIR" ]; then

--- a/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+++ b/De1.5_A2_Filtrado_NanoFilt_1.1.sh
@@ -20,10 +20,21 @@ else
     echo "NanoFilt ya está instalado. Se procede al Filtrado"
 fi
 
-# Definir los directorios de entrada y salida
-input_dir="/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed/"  # Cambia esta ruta según tu ubicación de entrada
-output_dir="/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed/filtered2/"
-log_file="/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed/filtered2/filtering_process.log"
+# Uso:
+#   INPUT_DIR=dir_de_entrada OUTPUT_DIR=dir_de_salida LOG_FILE=registro.log ./De1.5_A2_Filtrado_NanoFilt_1.1.sh
+#   o bien
+#   ./De1.5_A2_Filtrado_NanoFilt_1.1.sh <dir_entrada> <dir_salida> <archivo_log>
+
+# Directorios y archivo de log configurables
+input_dir="${INPUT_DIR:-$1}"
+output_dir="${OUTPUT_DIR:-$2}"
+log_file="${LOG_FILE:-$3}"
+
+if [ -z "$input_dir" ] || [ -z "$output_dir" ] || [ -z "$log_file" ]; then
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> LOG_FILE=<archivo log> $0"
+    echo "   o: $0 <dir entrada> <dir salida> <archivo log>"
+    exit 1
+fi
 
 # Crear el directorio de salida si no existe
 mkdir -p "$output_dir"

--- a/De1_A1.5_Trim_Fastq.sh
+++ b/De1_A1.5_Trim_Fastq.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
-# DEFINIR DIRECTORIOS
-INPUT_DIR="/home/adriano_abb/Qiime/V2/ParaPoster/parsed"          # Reemplazá con tu directorio real de entrada
-OUTPUT_DIR="/home/adriano_abb/Qiime/V2/ParaPoster/parsed/trimmed"    # Reemplazá con donde querés guardar los recortados
+# Uso:
+#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./De1_A1.5_Trim_Fastq.sh
+#   o: ./De1_A1.5_Trim_Fastq.sh <dir_entrada> <dir_salida>
+
+# Directorios de entrada y salida configurables
+INPUT_DIR="${INPUT_DIR:-$1}"
+OUTPUT_DIR="${OUTPUT_DIR:-$2}"
+
+if [ -z "$INPUT_DIR" ] || [ -z "$OUTPUT_DIR" ]; then
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0"
+    echo "   o: $0 <dir entrada> <dir salida>"
+    exit 1
+fi
 
 # CREAR CARPETA DE SALIDA SI NO EXISTE
 mkdir -p "$OUTPUT_DIR"

--- a/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-# Directorio base donde están las carpetas
-BASE_DIR="/home/adriano_abb/Qiime/Res_Experim/expCOI/clustered"
+# Uso:
+#   BASE_DIR=/ruta/a/clustered OUTPUT_DIR=/ruta/a/unificado ./De2.5_A3_NGSpecies_Unificar_Clusters.sh
+#   o: ./De2.5_A3_NGSpecies_Unificar_Clusters.sh <dir_base> <dir_salida>
 
-# Directorio de salida donde se guardarán los archivos unificados
-DIR_SALIDA="$BASE_DIR/Consensos_unificado"
+# Directorio base donde están las carpetas y de salida
+BASE_DIR="${BASE_DIR:-$1}"
+DIR_SALIDA="${OUTPUT_DIR:-$2}"
+
+if [ -z "$BASE_DIR" ] || [ -z "$DIR_SALIDA" ]; then
+    echo "Uso: BASE_DIR=<dir base> OUTPUT_DIR=<dir salida> $0"
+    echo "   o: $0 <dir base> <dir salida>"
+    exit 1
+fi
 
 # Crear el directorio de salida si no existe
 mkdir -p "$DIR_SALIDA"

--- a/De2_A2.5_NGSpecies_Clustering.sh
+++ b/De2_A2.5_NGSpecies_Clustering.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
-# Directorio que contiene los archivos .fastq
-input_dir="/home/adriano_abb/Qiime/V2/Juan/Clust_By_NGSpecies/Archivos_Ejemplo/Test"
-output_dir="/home/adriano_abb/Qiime/V2/Juan/Clust_By_NGSpecies/Archivos_Ejemplo/Test/clustered/" 
+# Uso:
+#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./De2_A2.5_NGSpecies_Clustering.sh
+#   o: ./De2_A2.5_NGSpecies_Clustering.sh <dir_entrada> <dir_salida>
+
+# Directorio que contiene los archivos .fastq y salida configurables
+input_dir="${INPUT_DIR:-$1}"
+output_dir="${OUTPUT_DIR:-$2}"
+
+if [ -z "$input_dir" ] || [ -z "$output_dir" ]; then
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0"
+    echo "   o: $0 <dir entrada> <dir salida>"
+    exit 1
+fi
 
 # Crear el directorio de salida si no existe
 mkdir -p "$output_dir"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ClipON
+
 “ClipON: pipeline reproducible para metabarcoding de eDNA (marcador COI) con lecturas Nanopore – limpieza, clustering, clasificación.”
+
+## Uso rápido
+
+Ejecuta todo el flujo con:
+
+```bash
+./run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
+```
+
+Esto creará subdirectorios dentro de `<dir_trabajo>` para cada etapa.
+Las rutas de entrada y salida también pueden configurarse manualmente al invocar cada script por separado.
+

--- a/run_clipon_pipeline.sh
+++ b/run_clipon_pipeline.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Wrapper para ejecutar la cadena completa de procesamiento de ClipON
+# Uso: ./run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
+# El directorio de trabajo contendrá subcarpetas para cada etapa
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Uso: $0 <dir_fastq_entrada> <dir_trabajo>"
+    exit 1
+fi
+
+INPUT_DIR="$1"
+WORK_DIR="$2"
+
+# Definir subdirectorios
+PROCESSED_DIR="$WORK_DIR/1_processed"
+TRIM_DIR="$WORK_DIR/2_trimmed"
+FILTER_DIR="$WORK_DIR/3_filtered"
+CLUSTER_DIR="$WORK_DIR/4_clustered"
+UNIFIED_DIR="$WORK_DIR/5_unified"
+LOG_FILE="$FILTER_DIR/nanofilt.log"
+
+mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR"
+
+# Ejecutar paso 1: limpieza con SeqKit
+INPUT_DIR="$INPUT_DIR" OUTPUT_DIR="$PROCESSED_DIR" ./De0_A1_Process_Fastq.4_SeqKit.sh
+
+# Paso 2: recorte de cebadores
+INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" ./De1_A1.5_Trim_Fastq.sh
+
+# Paso 3: filtrado por calidad y longitud
+INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" ./De1.5_A2_Filtrado_NanoFilt_1.1.sh
+
+# Paso 4: clusterizado con NGSpeciesID
+INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" ./De2_A2.5_NGSpecies_Clustering.sh
+
+# Paso 5: unificación de clusters
+BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" ./De2.5_A3_NGSpecies_Unificar_Clusters.sh
+
+echo "Pipeline completado. Resultados en: $WORK_DIR"


### PR DESCRIPTION
## Summary
- add usage instructions to CLIPON bash scripts
- allow setting input/output dirs via env variables or arguments
- add wrapper script

## Testing
- `INPUT_DIR=test_data/input_fastq OUTPUT_DIR=test_data/seqkit_output ./De0_A1_Process_Fastq.4_SeqKit.sh` *(fails: SeqKit no está instalado)*
- `OUTPUT_DIR=test_data/trim_output INPUT_DIR=test_data/input_fastq ./De1_A1.5_Trim_Fastq.sh` *(fails: cutadapt no encontrado)*
- `INPUT_DIR=test_data/input_fastq OUTPUT_DIR=test_data/nanofilt_output LOG_FILE=test_data/nanofilt.log ./De1.5_A2_Filtrado_NanoFilt_1.1.sh` *(fails: conda no encontrado)*
- `INPUT_DIR=test_data/input_fastq OUTPUT_DIR=test_data/ngscluster_output ./De2_A2.5_NGSpecies_Clustering.sh` *(fails: NGSpeciesID no encontrado)*
- `BASE_DIR=test_data/input_clusters OUTPUT_DIR=test_data/unified ./De2.5_A3_NGSpecies_Unificar_Clusters.sh` *(no encuentra secuencias)*
- `./run_clipon_pipeline.sh test_data/input_fastq test_data/workdir` *(fails: SeqKit no está instalado)*

------
https://chatgpt.com/codex/tasks/task_b_687d356a19d483218fe5e946519f7e60