### PR TITLE
Add manifest example and placeholder paths

### DIFF
--- a/ImportingManifest_Manual.csv
+++ b/ImportingManifest_Manual.csv
@@ -1,3 +1,3 @@
 sample-id,absolute-filepath,direction
-SAV_coi_mixgendil5,/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed/filtered2/cleaned_0_SAV_37C01C_Filt650_750_Q10.fastq,forward
-SAV_coi_mixampliccc,/home/adriano_abb/Qiime/V2/Juan/Limpieza_Filtrado_DeSecCrudas/Archivos_ejemplo_Mock/parsed/filtered2/cleaned_0_SAV_DA801D_Filt650_750_Q10.fastq,forward
+SAV_coi_mixgendil5,/path/to/cleaned_0_SAV_37C01C_Filt650_750_Q10.fastq,forward
+SAV_coi_mixampliccc,/path/to/cleaned_0_SAV_DA801D_Filt650_750_Q10.fastq,forward

--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ El entorno `clipon-qiime` también se reutiliza para el módulo **Classifier**.
 ```bash
 ./run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
 ```
+
+### Formato del Importing Manifest
+Consulte [docs/manifest_example.md](docs/manifest_example.md) para un ejemplo de `ImportingManifest_Manual.csv`. El archivo debe tener las columnas:
+`sample-id`, `absolute-filepath` y `direction`.

--- a/docs/manifest_example.md
+++ b/docs/manifest_example.md
@@ -1,0 +1,16 @@
+# Example Importing Manifest
+
+The `ImportingManifest_Manual.csv` file is used by QIIME2 for importing FASTQ files. It must contain the following columns:
+
+1. `sample-id` – unique name for the sample
+2. `absolute-filepath` – path to the FASTQ file for that sample
+3. `direction` – sequencing direction, usually `forward`
+
+Example:
+```csv
+sample-id,absolute-filepath,direction
+example1,/path/to/cleaned_sample1.fastq,forward
+example2,/path/to/cleaned_sample2.fastq,forward
+```
+
+Paths may be absolute or relative. Update them to point to your cleaned FASTQ files before running the pipeline.


### PR DESCRIPTION
## Summary
- anonymize ImportingManifest_Manual.csv by replacing user paths with `/path/to/*`
- create `docs/manifest_example.md` to document CSV format
- reference manifest documentation from README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687d458f57e883219fbff1ea46b54e9f