### PR TITLE
Add manifest generation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ El entorno `clipon-qiime` también se reutiliza para el módulo **Classifier**.
 ./De2.5_A3_NGSpecies_Unificar_Clusters.sh <dir_base> <dir_salida>
 ```
 
+### Generar manifest automáticamente
+El archivo `manifest.csv` requerido por QIIME2 puede crearse con:
+
+```bash
+./scripts/generate_manifest.sh --filtered 3_filtered > manifest.csv
+```
+
+o bien utilizando las salidas de NGSpeciesID:
+
+```bash
+./scripts/generate_manifest.sh --ngspecies 4_clustered > manifest.csv
+```
+
 ### Clasificación con QIIME2
 ```bash
 ./De2_A4__VSearch_Procesonuevo2.6.1.sh <manifest.tsv> <prefijo> <dirDB> <email> <cluster_identity> <blast_identity> <maxaccepts>

--- a/scripts/generate_manifest.sh
+++ b/scripts/generate_manifest.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+set -u
+
+usage() {
+    echo "Usage: $0 (--filtered DIR | --ngspecies DIR)" >&2
+    exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+fi
+
+mode="$1"
+input_dir="$2"
+
+if [ ! -d "$input_dir" ]; then
+    echo "Directory not found: $input_dir" >&2
+    exit 1
+fi
+
+# Print CSV header
+echo "sample-id,absolute-filepath,direction"
+
+case "$mode" in
+    --filtered)
+        shopt -s nullglob
+        for f in "$input_dir"/*.fastq "$input_dir"/*.fq; do
+            [ -f "$f" ] || continue
+            sample=$(basename "$f")
+            sample=${sample%.fastq}
+            sample=${sample%.fq}
+            abs=$(readlink -f "$f")
+            echo "${sample},${abs},forward"
+        done
+        ;;
+    --ngspecies)
+        for d in "$input_dir"/*; do
+            [ -d "$d" ] || continue
+            sample=$(basename "$d")
+            file=""
+            if [ -f "$d/consensus.fastq" ]; then
+                file="$d/consensus.fastq"
+            elif [ -f "$d/consensus.fasta" ]; then
+                file="$d/consensus.fasta"
+            else
+                candidate=$(find "$d" -maxdepth 1 -type f \( -name '*.fastq' -o -name '*.fasta' -o -name '*.fa' \) | head -n 1)
+                if [ -n "$candidate" ]; then
+                    file="$candidate"
+                else
+                    continue
+                fi
+            fi
+            abs=$(readlink -f "$file")
+            echo "${sample},${abs},forward"
+        done
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary
- provide `scripts/generate_manifest.sh` to build SingleEndFastq manifests
- document usage in README with example commands

## Testing
- `bash -n scripts/generate_manifest.sh`

------
https://chatgpt.com/codex/tasks/task_b_687d782568f88321bf6d3ec10181fc0c