### PR TITLE
Make VSearch runner configurable

### DIFF
--- a/De2_A4_VSearch_ejecutador_combinaciones1.1.sh
+++ b/De2_A4_VSearch_ejecutador_combinaciones1.1.sh
@@ -2,11 +2,18 @@
 set -e
 set -u
 
-# Parámetros fijos
-manifest_file="SingleFastaPrueba_Filt.tsv"
-prefix="SingleFastaPrueba_Filt_Parana"
-dirDB="NCBI_Parana_Peces"
-email="adriano.abbondanzieri@gmail.com"
+# Parámetros pasados por variables de entorno o argumentos
+manifest_file="${MANIFEST_FILE:-${1-}}"
+prefix="${PREFIX:-${2-}}"
+dirDB="${DIRDB:-${3-}}"
+email="${EMAIL:-${4-}}"
+
+# Mostrar mensaje de uso si faltan argumentos
+if [[ -z "$manifest_file" || -z "$prefix" || -z "$dirDB" || -z "$email" ]]; then
+    echo "Uso: $0 <manifest_file> <prefijo> <dirDB> <email>" >&2
+    echo "O defina las variables de entorno MANIFEST_FILE, PREFIX, DIRDB y EMAIL" >&2
+    exit 1
+fi
 
 # Combinaciones de cluster_identity y blast_identity y maxaccepts
 combinaciones=("0.98 0.5 5")
@@ -20,7 +27,7 @@ for combinacion in "${combinaciones[@]}"; do
     echo "Ejecutando con cluster_identity=${cluster_identity}; blast_identity=${blast_identity} y maxaccepts=${maxaccepts}..."
     
     # Ejecutar el script con los parámetros correspondientes
-    ./nuevo2.6.1.sh "$manifest_file" "$prefix" "$dirDB" "$email" "$cluster_identity" "$blast_identity" "$maxaccepts"
+    ./De2_A4__VSearch_Procesonuevo2.6.1.sh "$manifest_file" "$prefix" "$dirDB" "$email" "$cluster_identity" "$blast_identity" "$maxaccepts"
     
     # Verificar si hubo un error
     if [ $? -ne 0 ]; then

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ El entorno `clipon-qiime` también se reutiliza para el módulo **Classifier**.
 ```bash
 ./De2_A4__VSearch_Procesonuevo2.6.1.sh <manifest.tsv> <prefijo> <dirDB> <email> <cluster_identity> <blast_identity> <maxaccepts>
 ```
+Para ejecutar todas las combinaciones de parámetros de forma automática puede usarse
+`De2_A4_VSearch_ejecutador_combinaciones1.1.sh`. Los valores de manifiesto, prefijo,
+base de datos y correo pueden pasarse como argumentos o mediante variables de entorno:
+```bash
+MANIFEST_FILE=manifest.tsv PREFIX=prueba DIRDB=NCBI_DB EMAIL=me@example.com \
+./De2_A4_VSearch_ejecutador_combinaciones1.1.sh
+```
 
 ### Ejecución completa
 ```bash


### PR DESCRIPTION
## Summary
- derive parameters from env vars or args for `De2_A4_VSearch_ejecutador_combinaciones1.1.sh`
- call `De2_A4__VSearch_Procesonuevo2.6.1.sh` in the loop
- document new usage in README
- retain executable bit on the script

## Testing
- `bash -n De2_A4_VSearch_ejecutador_combinaciones1.1.sh`


------
https://chatgpt.com/codex/tasks/task_b_687d779f7d588321aa81e843160c047b