### PR TITLE
Add trimming options to interactive pipeline

### DIFF
--- a/scripts/De1_A1.5_Trim_Fastq.sh
+++ b/scripts/De1_A1.5_Trim_Fastq.sh
@@ -28,8 +28,8 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 # Valores de recorte configurables
-TRIM_FRONT="${TRIM_FRONT:-30}"
-TRIM_BACK="${TRIM_BACK:-30}"
+TRIM_FRONT="${TRIM_FRONT:}"
+TRIM_BACK="${TRIM_BACK:}"
 
 # RECORRER ARCHIVOS FASTQ EN EL DIRECTORIO DE ENTRADA
 for file in "$INPUT_DIR"/*.fastq; do

--- a/scripts/De1_A1.5_Trim_Fastq.sh
+++ b/scripts/De1_A1.5_Trim_Fastq.sh
@@ -19,10 +19,14 @@ fi
 # CREAR CARPETA DE SALIDA SI NO EXISTE
 mkdir -p "$OUTPUT_DIR"
 
+# Valores de recorte configurables
+TRIM_FRONT="${TRIM_FRONT:-30}"
+TRIM_BACK="${TRIM_BACK:-30}"
+
 # RECORRER ARCHIVOS FASTQ EN EL DIRECTORIO DE ENTRADA
 for file in "$INPUT_DIR"/*.fastq; do
     filename=$(basename "$file")
-    cutadapt -u 30 -u -30 -o "$OUTPUT_DIR/${filename%.fastq}_trimmed.fastq" "$file"
+    cutadapt -u "$TRIM_FRONT" -u "-$TRIM_BACK" -o "$OUTPUT_DIR/${filename%.fastq}_trimmed.fastq" "$file"
 done
 
 # INFORMAR FINALIZACIÓN

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+# Script interactivo para ejecutar el pipeline de ClipON paso a paso
+
+echo "========================================================="
+echo "Bienvenido al asistente de ejecución de ClipON"
+echo "Este script lo guiará para preparar e iniciar el pipeline."
+echo "========================================================="
+read -rp "Presione Enter para comenzar" _
+
+echo "\n-- Verificando instalación de Conda --"
+if ! command -v conda >/dev/null; then
+    echo "No se encontró 'conda' en el sistema."
+    read -rp "¿Desea instalar Miniconda? (y/n) " ans
+    if [[ $ans =~ ^[Yy]$ ]]; then
+        echo "Por favor instale Miniconda desde: https://docs.conda.io/en/latest/miniconda.html"
+        echo "Luego vuelva a ejecutar este script."
+        exit 1
+    else
+        echo "No es posible continuar sin conda. Abortando."
+        exit 1
+    fi
+else
+    echo "Conda detectado."
+fi
+
+# Verificar entornos requeridos
+REQUIRED_ENVS=(clipon-prep clipon-qiime clipon-ngs)
+for env in "${REQUIRED_ENVS[@]}"; do
+    if conda env list | awk '{print $1}' | grep -Fxq "$env"; then
+        echo "Entorno '$env' encontrado."
+    else
+        echo "Entorno '$env' no encontrado."
+        read -rp "¿Crear entorno '$env'? (y/n) " create
+        if [[ $create =~ ^[Yy]$ ]]; then
+            if [ -f "envs/${env}.yml" ]; then
+                conda env create -f "envs/${env}.yml"
+            else
+                echo "Archivo envs/${env}.yml no existe."
+            fi
+        fi
+    fi
+    echo
+done
+
+read -rp "Ingrese el directorio que contiene los archivos FASTQ: " INPUT_DIR
+if [ ! -d "$INPUT_DIR" ]; then
+    echo "El directorio '$INPUT_DIR' no existe o no es accesible."
+    exit 1
+fi
+shopt -s nullglob
+fastqs=("$INPUT_DIR"/*.fastq "$INPUT_DIR"/*.fq)
+shopt -u nullglob
+if [ ${#fastqs[@]} -eq 0 ]; then
+    echo "No se encontraron archivos FASTQ en '$INPUT_DIR'. Puede que no sea un directorio válido."
+    exit 1
+fi
+
+read -rp "Ingrese el directorio de trabajo donde se guardarán los resultados: " WORK_DIR
+mkdir -p "$WORK_DIR"
+
+# Paso opcional de recorte de secuencias
+read -rp "¿Desea recortar las secuencias con cutadapt? (y/n) " do_trim
+if [[ $do_trim =~ ^[Yy]$ ]]; then
+    read -rp "Número de bases a recortar del inicio: " TRIM_FRONT
+    read -rp "Número de bases a recortar del final: " TRIM_BACK
+    SKIP_TRIM=0
+else
+    SKIP_TRIM=1
+    TRIM_FRONT=0
+    TRIM_BACK=0
+fi
+
+echo "\nResumen de configuración:"
+echo "  Directorio FASTQ: $INPUT_DIR"
+echo "  Directorio de trabajo: $WORK_DIR"
+if [ "$SKIP_TRIM" -eq 1 ]; then
+    echo "  Recorte: no"
+else
+    echo "  Recorte: sí (inicio $TRIM_FRONT, final $TRIM_BACK)"
+fi
+read -rp "¿Continuar con la ejecución del pipeline? (y/n) " go
+if [[ ! $go =~ ^[Yy]$ ]]; then
+    echo "Operación cancelada por el usuario."
+    exit 0
+fi
+
+echo "\nIniciando pipeline..."
+
+SKIP_TRIM="$SKIP_TRIM" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" \
+    scripts/run_clipon_pipeline.sh "$INPUT_DIR" "$WORK_DIR"
+
+echo "Ejecución finalizada. Resultados en: $WORK_DIR"

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -14,6 +14,11 @@ fi
 INPUT_DIR="$1"
 WORK_DIR="$2"
 
+# Configuración opcional para el recorte
+SKIP_TRIM="${SKIP_TRIM:-0}"
+TRIM_FRONT="${TRIM_FRONT:-30}"
+TRIM_BACK="${TRIM_BACK:-30}"
+
 # Definir subdirectorios
 PROCESSED_DIR="$WORK_DIR/1_processed"
 TRIM_DIR="$WORK_DIR/2_trimmed"
@@ -27,8 +32,13 @@ mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR
 # Ejecutar paso 1: limpieza con SeqKit
 INPUT_DIR="$INPUT_DIR" OUTPUT_DIR="$PROCESSED_DIR" ./scripts/De0_A1_Process_Fastq.4_SeqKit.sh
 
-# Paso 2: recorte de cebadores
-INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" ./scripts/De1_A1.5_Trim_Fastq.sh
+# Paso 2: recorte de cebadores (opcional)
+if [ "$SKIP_TRIM" -eq 1 ]; then
+    echo "Omitiendo recorte de secuencias."
+    cp "$PROCESSED_DIR"/*.fastq "$TRIM_DIR"/
+else
+    INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" ./scripts/De1_A1.5_Trim_Fastq.sh
+fi
 
 # Paso 3: filtrado por calidad y longitud
 INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" ./scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh


### PR DESCRIPTION
## Summary
- add optional trimming prompt to `run_clipon_interactive.sh`
- support skipping trimming and custom cutadapt values in `run_clipon_pipeline.sh`
- allow trim lengths to be configured in `De1_A1.5_Trim_Fastq.sh`

## Testing
- `bash -n scripts/run_clipon_interactive.sh`
- `bash -n scripts/run_clipon_pipeline.sh`
- `bash -n scripts/De1_A1.5_Trim_Fastq.sh`


------
https://chatgpt.com/codex/tasks/task_b_687d91babc0083218e86a31cc8bf99c5