### PR TITLE
Reduce console output and log seqkit results

### DIFF
--- a/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
+++ b/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
@@ -3,9 +3,8 @@ set -e
 set -u
 
 # Verificar si seqkit está instalado
-if ! command -v seqkit &> /dev/null
-then
-    echo "SeqKit no está instalado. Por favor, instálalo antes de continuar."
+if ! command -v seqkit &> /dev/null; then
+    echo "SeqKit no está instalado. Por favor, instálalo antes de continuar." >&2
     exit 1
 fi
 
@@ -17,45 +16,52 @@ fi
 # Directorios de entrada y salida configurables por variables o argumentos
 INPUT_DIR="${INPUT_DIR:-$1}"
 OUTPUT_DIR="${OUTPUT_DIR:-$2}"
+LOG_FILE="${LOG_FILE:-"$OUTPUT_DIR/process_fastq.log"}"
 
 # Comprobar que se proporcionaron las rutas
 if [ -z "$INPUT_DIR" ] || [ -z "$OUTPUT_DIR" ]; then
-    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0"
-    echo "   o: $0 <dir entrada> <dir salida>"
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0" >&2
+    echo "   o: $0 <dir entrada> <dir salida>" >&2
     exit 1
 fi
 
 # Verificar si los directorios existen
 if [ ! -d "$INPUT_DIR" ]; then
-    echo "El directorio de entrada no existe: $INPUT_DIR"
+    echo "El directorio de entrada no existe: $INPUT_DIR" >&2
     exit 1
 fi
 
 if [ ! -d "$OUTPUT_DIR" ]; then
-    echo "El directorio de salida no existe, creando..."
     mkdir -p "$OUTPUT_DIR"
 fi
 
+# Crear o vaciar archivo de log
+printf "Log de De0_A1_Process_Fastq.4_SeqKit.sh - %s\n" "$(date)" > "$LOG_FILE"
+
 # Procesar cada archivo FASTQ en el directorio de entrada
+files_processed=0
 for file in "$INPUT_DIR"/*.fastq; do
     if [ -f "$file" ]; then
-        echo "Procesando archivo: $file"
+        files_processed=$((files_processed + 1))
+        {
+            echo "Procesando archivo: $file"
 
-        # Filtrar secuencias mal formateadas con seqkit sana
-        CLEANED_FILE="${OUTPUT_DIR}/cleaned_$(basename "$file")"
-        echo "Filtrando secuencias mal formateadas con seqkit sana: $CLEANED_FILE"
-        
-        # Filtrar las secuencias mal formateadas
-        seqkit sana "$file" -o "$CLEANED_FILE"
+            # Filtrar secuencias mal formateadas con seqkit sana
+            CLEANED_FILE="${OUTPUT_DIR}/cleaned_$(basename "$file")"
+            echo "Filtrando secuencias mal formateadas con seqkit sana: $CLEANED_FILE"
 
-        # Verificar si el archivo tiene contenido después del filtrado
-        if [ ! -s "$CLEANED_FILE" ]; then
-            echo "Advertencia: El archivo $file no tiene secuencias válidas después del filtrado. Se omite."
-            continue
-        fi
+            # Filtrar las secuencias mal formateadas
+            seqkit sana "$file" -o "$CLEANED_FILE"
 
-        echo "Archivo limpio guardado en: $CLEANED_FILE"
+            # Verificar si el archivo tiene contenido después del filtrado
+            if [ ! -s "$CLEANED_FILE" ]; then
+                echo "Advertencia: El archivo $file no tiene secuencias válidas después del filtrado. Se omite."
+                continue
+            fi
+
+            echo "Archivo limpio guardado en: $CLEANED_FILE"
+        } >> "$LOG_FILE" 2>&1
     fi
 done
 
-echo "Proceso completado. Los archivos filtrados están en: $OUTPUT_DIR"
+echo "Proceso completado. Se procesaron $files_processed archivos. Detalles en $LOG_FILE. Los archivos filtrados están en: $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- redirect detailed output from `De0_A1_Process_Fastq.4_SeqKit.sh` into a log file
- show only a concise summary in the console

## Testing
- `bash -n scripts/De0_A1_Process_Fastq.4_SeqKit.sh`

------
https://chatgpt.com/codex/tasks/task_b_687da08f50908321aaa51219873b5e8c