### PR TITLE
Fix default trim values

### DIFF
--- a/scripts/De1_A1.5_Trim_Fastq.sh
+++ b/scripts/De1_A1.5_Trim_Fastq.sh
@@ -29,13 +29,14 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 # Valores de recorte configurables
-TRIM_FRONT="${TRIM_FRONT:}"
-TRIM_BACK="${TRIM_BACK:}"
+# Si las variables no están definidas usar 0 y -0 respectivamente
+TRIM_FRONT="${TRIM_FRONT:-0}"
+TRIM_BACK="${TRIM_BACK:--0}"
 
 # RECORRER ARCHIVOS FASTQ EN EL DIRECTORIO DE ENTRADA
 for file in "$INPUT_DIR"/*.fastq; do
     filename=$(basename "$file")
-    cutadapt -u "$TRIM_FRONT" -u "-$TRIM_BACK" -o "$OUTPUT_DIR/${filename%.fastq}_trimmed.fastq" "$file"
+    cutadapt -u "$TRIM_FRONT" -u "-${TRIM_BACK#-}" -o "$OUTPUT_DIR/${filename%.fastq}_trimmed.fastq" "$file"
 done
 
 # INFORMAR FINALIZACIÓN


### PR DESCRIPTION
## Summary
- avoid bad parameter substitution when optional trim vars are unset
- handle negative sign for trim-back default

## Testing
- `bash -n scripts/De1_A1.5_Trim_Fastq.sh`
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687da5db1a1c832185a39f9bf7dc2073