### PR TITLE
Update manifest script for new pipeline layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ manual.  El entorno `clipon-qiime` también se reutiliza para el módulo
 El archivo `manifest.csv` requerido por QIIME2 puede crearse con:
 
 ```bash
-./scripts/generate_manifest.sh --filtered 3_filtered > manifest.csv
+./scripts/generate_manifest.sh --workdir <dir_trabajo> filtered > manifest.csv
 ```
 
-o bien utilizando las salidas de NGSpeciesID:
+También puede generarse a partir de los consensos unificados:
 
 ```bash
-./scripts/generate_manifest.sh --ngspecies 4_clustered > manifest.csv
+./scripts/generate_manifest.sh --workdir <dir_trabajo> unified > manifest.csv
 ```
 
 ### Clasificación con QIIME2

--- a/scripts/generate_manifest.sh
+++ b/scripts/generate_manifest.sh
@@ -3,16 +3,44 @@ set -e
 set -u
 
 usage() {
-    echo "Usage: $0 (--filtered DIR | --ngspecies DIR)" >&2
+    cat >&2 <<'EOF'
+Usage: $0 (--filtered DIR | --unified DIR | --workdir DIR STEP)
+
+Generate a QIIME2 manifest from the ClipON pipeline outputs.
+
+  --filtered DIR      Directory containing filtered FASTQ files.
+  --unified DIR       Directory produced by the unification step.
+  --workdir DIR STEP  Use DIR/3_filtered or DIR/5_unified depending on STEP
+                      (filtered|unified).
+EOF
     exit 1
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 2 ]; then
     usage
 fi
 
 mode="$1"
 input_dir="$2"
+
+if [ "$mode" = "--workdir" ]; then
+    if [ "$#" -ne 3 ]; then
+        usage
+    fi
+    case "$3" in
+        filtered)
+            mode="--filtered"
+            input_dir="$input_dir/3_filtered"
+            ;;
+        unified)
+            mode="--unified"
+            input_dir="$input_dir/5_unified"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+fi
 
 if [ ! -d "$input_dir" ]; then
     echo "Directory not found: $input_dir" >&2
@@ -34,24 +62,14 @@ case "$mode" in
             echo "${sample},${abs},forward"
         done
         ;;
-    --ngspecies)
-        for d in "$input_dir"/*; do
-            [ -d "$d" ] || continue
-            sample=$(basename "$d")
-            file=""
-            if [ -f "$d/consensus.fastq" ]; then
-                file="$d/consensus.fastq"
-            elif [ -f "$d/consensus.fasta" ]; then
-                file="$d/consensus.fasta"
-            else
-                candidate=$(find "$d" -maxdepth 1 -type f \( -name '*.fastq' -o -name '*.fasta' -o -name '*.fa' \) | head -n 1)
-                if [ -n "$candidate" ]; then
-                    file="$candidate"
-                else
-                    continue
-                fi
-            fi
-            abs=$(readlink -f "$file")
+    --unified)
+        shopt -s nullglob
+        for f in "$input_dir"/consensos_*.fasta; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f")
+            sample=${base#consensos_}
+            sample=${sample%.fasta}
+            abs=$(readlink -f "$f")
             echo "${sample},${abs},forward"
         done
         ;;

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -46,11 +46,8 @@ if [ "$SKIP_TRIM" -eq 1 ]; then
     echo "Omitiendo recorte de secuencias."
     cp "$PROCESSED_DIR"/*.fastq "$TRIM_DIR"/
 else
-    INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" ./scripts/De1_A1.5_Trim_Fastq.sh
+    INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" "$script_dir/De1_A1.5_Trim_Fastq.sh"
 fi
-=======
-# Paso 2: recorte de cebadores
-INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" "$script_dir/De1_A1.5_Trim_Fastq.sh"
 
 # Paso 3: filtrado por calidad y longitud
 INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" "$script_dir/De1.5_A2_Filtrado_NanoFilt_1.1.sh"


### PR DESCRIPTION
## Summary
- drop support for non-unified NGSpeciesID manifests
- adjust run_clipon_pipeline.sh after merge conflict
- update README usage

## Testing
- `bash -n scripts/generate_manifest.sh`
- `bash -n scripts/run_clipon_pipeline.sh`
- `./scripts/generate_manifest.sh --workdir /tmp/test_pipeline filtered`
- `./scripts/generate_manifest.sh --workdir /tmp/test_pipeline unified`


------
https://chatgpt.com/codex/tasks/task_b_687da31a46188321a3a0cc723d268d43