### PR TITLE
Fix function name typo in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ o bien utilizando las salidas de NGSpeciesID:
 ```bash
 ./scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh <manifest.tsv> <prefijo> <dirDB> <email> <cluster_identity> <blast_identity> <maxaccepts>
 ```
+La clasificación se realiza dentro de la función `clasificar_secuencias` de dicho script.
 Para ejecutar todas las combinaciones de parámetros de forma automática puede usarse
 `scripts/De2_A4_VSearch_ejecutador_combinaciones1.1.sh`. Los valores de manifiesto, prefijo,
 base de datos y correo pueden pasarse como argumentos o mediante variables de entorno:

--- a/scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh
+++ b/scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh
@@ -138,7 +138,7 @@ process_manifest() {
 }
 
 # Clasificar secuencias con BLAST
-classificar_secuencias() {
+clasificar_secuencias() {
     echo "Clasificando secuencias con BLAST..."
     local start_time=$(date +%s)
 
@@ -226,7 +226,7 @@ echo -e "Subject: $SUBJECT\n\n$BODY" | msmtp -a gmail "$email"
 
 # Ejecución de funciones
 process_manifest
-classificar_secuencias
+clasificar_secuencias
 extraer_datos
 
 # Notificación de finalización


### PR DESCRIPTION
## Summary
- rename `classificar_secuencias` to `clasificar_secuencias`
- document the updated function name in README

## Testing
- `bash -n scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh`


------
https://chatgpt.com/codex/tasks/task_b_687da46bbe508321bceb4dd083bf55f3