### PR TITLE
Add environment check before interactive ClipON pipeline

### DIFF
--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -7,6 +7,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Verificar que los entornos requeridos funcionen correctamente
+if ! "$SCRIPT_DIR/test_envs.sh"; then
+    echo "Fallo en la verificación de entornos. Abortando."
+    exit 1
+fi
+
 echo "========================================================="
 echo "Bienvenido al asistente de ejecución de ClipON"
 echo "Este script lo guiará para preparar e iniciar el pipeline."


### PR DESCRIPTION
## Summary
- Ensure `run_clipon_interactive.sh` invokes `test_envs.sh` before proceeding
- Abort interactive pipeline when environment verification fails

## Testing
- `bash -n scripts/run_clipon_interactive.sh`
- `bash scripts/test_envs.sh` *(fails: Conda no se encontró en el sistema)*

------
https://chatgpt.com/codex/tasks/task_b_689abb995b8c83218c5c64c75ac3dda3