### PR TITLE
Add read statistics collection and relative script paths

### DIFF
--- a/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
+++ b/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
@@ -61,6 +61,11 @@ for file in "$INPUT_DIR"/*.fastq; do
             fi
 
             echo "Archivo limpio guardado en: $CLEANED_FILE"
+
+            # Generar estadísticas de lecturas para archivos crudos y procesados
+            base_name="$(basename "$file" .fastq)"
+            python scripts/collect_read_stats.py "$file" "$OUTPUT_DIR/${base_name}_raw_stats.tsv"
+            python scripts/collect_read_stats.py "$CLEANED_FILE" "$OUTPUT_DIR/${base_name}_processed_stats.tsv"
         } >> "$LOG_FILE" 2>&1
     fi
 done

--- a/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+++ b/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
@@ -40,11 +40,13 @@ for file in "$input_dir"/*.fastq; do
 
     # Ejecutar NanoFilt y guardar en formato FASTQ
     echo "Filtrando $file..." >> "$log_file"
-    cat "$file" | NanoFilt -l 650 --maxlength 750 -q 10 > "$output_dir/${base_name}_Filt650_750_Q10.fastq" 2>> "$log_file"
+    output_file="$output_dir/${base_name}_Filt650_750_Q10.fastq"
+    cat "$file" | NanoFilt -l 650 --maxlength 750 -q 10 > "$output_file" 2>> "$log_file"
 
     # Verificar si el proceso fue exitoso
     if [ $? -eq 0 ]; then
         echo "Filtrado completado para $file" >> "$log_file"
+        python scripts/collect_read_stats.py "$output_file" "$output_dir/${base_name}_filtered_stats.tsv" >> "$log_file" 2>&1
     else
         echo "Hubo un error al filtrar $file" >> "$log_file"
     fi

--- a/scripts/collect_read_stats.py
+++ b/scripts/collect_read_stats.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Collect basic read statistics from a FASTQ file.
+
+Outputs a TSV with per-read length and mean quality score.
+Usage: python scripts/collect_read_stats.py <fastq> <output_tsv>
+"""
+import sys
+import csv
+
+if len(sys.argv) != 3:
+    print("Usage: collect_read_stats.py <fastq> <output_tsv>", file=sys.stderr)
+    sys.exit(1)
+
+fastq_path = sys.argv[1]
+out_tsv = sys.argv[2]
+
+try:
+    fh_fastq = open(fastq_path)
+except OSError as e:
+    print(f"Could not open FASTQ file: {e}", file=sys.stderr)
+    sys.exit(1)
+
+with fh_fastq, open(out_tsv, 'w', newline='') as out_fh:
+    writer = csv.writer(out_fh, delimiter='\t')
+    writer.writerow(["read_id", "length", "mean_quality"])
+
+    while True:
+        header = fh_fastq.readline().rstrip()
+        if not header:
+            break
+        seq = fh_fastq.readline().rstrip()
+        fh_fastq.readline()  # skip plus line
+        qual = fh_fastq.readline().rstrip()
+
+        read_id = header[1:].split()[0]
+        length = len(seq)
+        if length:
+            mean_q = sum(ord(c) - 33 for c in qual) / length
+        else:
+            mean_q = 0
+        writer.writerow([read_id, length, f"{mean_q:.2f}"])

--- a/scripts/plot_quality_vs_length.R
+++ b/scripts/plot_quality_vs_length.R
@@ -1,0 +1,18 @@
+#!/usr/bin/env Rscript
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+  stop("Usage: plot_quality_vs_length.R <stats_tsv> <output_png>")
+}
+input_tsv <- args[1]
+output_png <- args[2]
+
+suppressPackageStartupMessages(library(ggplot2))
+
+df <- read.table(input_tsv, header = TRUE, sep = "\t")
+
+p <- ggplot(df, aes(x = length, y = mean_quality)) +
+  geom_point(alpha = 0.4) +
+  labs(x = "Read length", y = "Mean quality score") +
+  theme_minimal()
+
+ggsave(output_png, plot = p, width = 6, height = 4)

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -3,12 +3,13 @@ set -e
 
 # Script interactivo para ejecutar el pipeline de ClipON paso a paso
 
-# Determinar la ruta de este script y la raíz del repositorio
+# Determinar la raíz del repositorio y usar rutas relativas
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
 
 # Verificar que los entornos requeridos funcionen correctamente
-if ! "$SCRIPT_DIR/test_envs.sh"; then
+if ! scripts/test_envs.sh; then
     echo "Fallo en la verificación de entornos. Abortando."
     exit 1
 fi
@@ -44,7 +45,7 @@ for env in "${REQUIRED_ENVS[@]}"; do
         echo "Entorno '$env' no encontrado."
         read -rp "¿Crear entorno '$env'? (y/n) " create
         if [[ $create =~ ^[Yy]$ ]]; then
-            env_file="$ROOT_DIR/envs/${env}.yml"
+            env_file="envs/${env}.yml"
             if [ -f "$env_file" ]; then
                 conda env create -f "$env_file"
             else
@@ -126,6 +127,6 @@ fi
 echo "\nIniciando pipeline..."
 
 SKIP_TRIM="$SKIP_TRIM" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" \
-    "$SCRIPT_DIR/run_clipon_pipeline.sh" "$INPUT_DIR" "$WORK_DIR"
+    scripts/run_clipon_pipeline.sh "$INPUT_DIR" "$WORK_DIR"
 
 echo "Ejecución finalizada. Resultados en: $WORK_DIR"


### PR DESCRIPTION
## Summary
- add scripts to collect read statistics and generate length vs quality plot
- run stats collection during FASTQ processing and filtering steps
- use relative paths for all pipeline and interactive script calls

## Testing
- `python -m py_compile scripts/collect_read_stats.py`
- `bash -n scripts/De0_A1_Process_Fastq.4_SeqKit.sh`
- `bash -n scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`
- `bash -n scripts/run_clipon_pipeline.sh`
- `bash -n scripts/run_clipon_interactive.sh`
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689abde056808321802591d58917712a