### PR TITLE
fix: enable newline in stage summary output

### DIFF
--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -79,4 +79,5 @@ bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
+echo -e "\nResumen de lecturas por etapa:"
 echo "Pipeline completado. Resultados en: $WORK_DIR"


### PR DESCRIPTION
## Summary
- print stage summary header with newline using `echo -e` for proper formatting

## Testing
- `bash -n scripts/run_clipon_pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_b_689ac0ee62188321bf1b092602f65d59