### PR TITLE
Add read quality plotting step

### DIFF
--- a/scripts/plot_quality_vs_length.R
+++ b/scripts/plot_quality_vs_length.R
@@ -1,18 +1,30 @@
 #!/usr/bin/env Rscript
+
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) != 2) {
-  stop("Usage: plot_quality_vs_length.R <stats_tsv> <output_png>")
+if (length(args) != 1) {
+  stop("Usage: plot_quality_vs_length.R <work_dir>")
 }
-input_tsv <- args[1]
-output_png <- args[2]
+
+work_dir <- args[1]
+file_cleaned <- file.path(work_dir, "read_stats_cleaned.tsv")
+file_filtered <- file.path(work_dir, "read_stats_650_750_Q10.tsv")
+output_png <- file.path(work_dir, "read_quality_vs_length.png")
 
 suppressPackageStartupMessages(library(ggplot2))
 
-df <- read.table(input_tsv, header = TRUE, sep = "\t")
+cleaned <- read.table(file_cleaned, header = TRUE, sep = "\t")
+cleaned$dataset <- "cleaned"
 
-p <- ggplot(df, aes(x = length, y = mean_quality)) +
+filtered <- read.table(file_filtered, header = TRUE, sep = "\t")
+filtered$dataset <- "filtered"
+
+df <- rbind(cleaned, filtered)
+
+p <- ggplot(df, aes(x = length, y = mean_quality, color = dataset)) +
   geom_point(alpha = 0.4) +
-  labs(x = "Read length", y = "Mean quality score") +
+  labs(x = "Read length", y = "Mean quality score", color = "Dataset") +
   theme_minimal()
 
 ggsave(output_png, plot = p, width = 6, height = 4)
+
+cat(output_png, "\n")

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -53,6 +53,10 @@ fi
 
 # Paso 3: filtrado por calidad y longitud
 INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+
+# Generar gráfico de calidad vs longitud
+PLOT_FILE=$(Rscript scripts/plot_quality_vs_length.R "$WORK_DIR")
+
 conda activate clipon-ngs
 
 # Paso 4: clusterizado con NGSpeciesID
@@ -80,3 +84,4 @@ bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
 echo "Pipeline completado. Resultados en: $WORK_DIR"
+echo "Gráfico de calidad vs longitud: $PLOT_FILE"


### PR DESCRIPTION
## Summary
- Add R script to merge read statistics and render read_quality_vs_length.png
- Run plotting script after filtering in run_clipon_pipeline.sh and report image path

## Testing
- `Rscript scripts/plot_quality_vs_length.R /tmp/work`


------
https://chatgpt.com/codex/tasks/task_b_689ac1e8b6d48321ba4c66031b8e4a71