### PR TITLE
feat: add read quality poster script

### DIFF
--- a/scripts/read_quality_poster.R
+++ b/scripts/read_quality_poster.R
@@ -1,0 +1,43 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(ggplot2)
+  library(RColorBrewer)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+  stop("Uso: read_quality_poster.R <tsv_paths_coma_separadas> <output_png>")
+}
+
+# Argumento 1: rutas separadas por comas a los TSV generados por collect_read_stats.py
+tsve <- strsplit(args[1], ",")[[1]]
+output_png <- args[2]
+
+if (length(tsve) == 0) {
+  stop("No se proporcionaron archivos TSV")
+}
+
+# Leer y combinar datos, añadiendo una columna con el nombre de la etapa
+data_list <- lapply(tsve, function(p) {
+  df <- read.table(p, header = TRUE, sep = "\t", stringsAsFactors = FALSE)
+  df$mean_quality <- as.numeric(df$mean_quality)
+  df$stage <- tools::file_path_sans_ext(basename(p))
+  df
+})
+
+df_all <- do.call(rbind, data_list)
+
+# Límites fijos para hacer comparables los gráficos entre etapas
+max_length <- 2000
+max_quality <- 45
+
+p <- ggplot(df_all, aes(x = length, y = mean_quality, color = stage)) +
+  geom_point(alpha = 0.5, size = 0.7) +
+  scale_color_brewer(palette = "Dark2") +
+  coord_cartesian(xlim = c(0, max_length), ylim = c(0, max_quality)) +
+  labs(x = "Longitud de lectura", y = "Calidad media", color = "Etapa") +
+  theme_minimal()
+
+# Guardar gráfico
+ggsave(output_png, plot = p, width = 8, height = 5, dpi = 300)

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -4,6 +4,9 @@
 # Uso: ./run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
 # El directorio de trabajo contendrá subcarpetas para cada etapa
 
+# Para un gráfico avanzado de la calidad de lectura combine los TSV generados en cada etapa (collect_read_stats.py):
+# Rscript scripts/read_quality_poster.R "ruta/etapa1.tsv,ruta/etapa2.tsv" salida.png
+
 set -e
 set -u
 set -o pipefail


### PR DESCRIPTION
## Summary
- add `read_quality_poster.R` for generating read quality plots from multiple stages with fixed axes and color palette
- document how to run the advanced quality plot in `run_clipon_pipeline.sh`

## Testing
- `Rscript scripts/read_quality_poster.R "sample1.tsv,sample2.tsv" output.png`
- `ls -l output.png`


------
https://chatgpt.com/codex/tasks/task_b_689ac30ba1cc83218efb6132802ab1f5