### PR TITLE
docs: reference read stats script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Las rutas de entrada y salida también pueden configurarse manualmente al invoca
 ./scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh <dir_entrada> <dir_salida> <log_file>
 ```
 
+### Estadísticas de lecturas
+Para obtener longitudes y calidades por lectura utilice el script ya incluido
+en el repositorio:
+
+```bash
+python scripts/collect_read_stats.py <archivo.fastq>
+```
+Así evita implementar herramientas duplicadas para esta tarea.
+
 ## Entornos Conda
 
 El repositorio incluye tres archivos de entorno en `envs/` para mantener

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -2,6 +2,8 @@
 set -e
 
 # Script interactivo para ejecutar el pipeline de ClipON paso a paso
+# Nota: la extracción de longitudes y calidades por lectura ya se realiza con
+# scripts/collect_read_stats.py
 
 # Determinar la raíz del repositorio y usar rutas relativas
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- note read length/quality extraction in interactive helper
- document existing `collect_read_stats.py` to avoid duplicate scripts

## Testing
- `bash -n scripts/run_clipon_interactive.sh && echo 'syntax ok'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ac4bc02f48321a7a3116ebabe37d4