### PR TITLE
Support multi-stage quality plots in pipeline

### DIFF
--- a/scripts/plot_quality_vs_length_multi.R
+++ b/scripts/plot_quality_vs_length_multi.R
@@ -1,0 +1,43 @@
+#!/usr/bin/env Rscript
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+  stop("Usage: plot_quality_vs_length_multi.R <output_png> <tsv1> <tsv2> [<tsv3> ...]")
+}
+
+output_png <- normalizePath(args[1], mustWork = FALSE)
+input_files <- args[-1]
+
+suppressPackageStartupMessages({
+  library(ggplot2)
+  library(readr)
+})
+
+# Read each TSV and add a group column based on filename
+get_group <- function(path) {
+  fname <- basename(path)
+  m <- regmatches(fname, regexpr("(processed|filtered)_stats\\.tsv$", fname))
+  if (length(m) == 1) {
+    sub("_stats.tsv", "", m)
+  } else {
+    tools::file_path_sans_ext(fname)
+  }
+}
+
+data_list <- lapply(input_files, function(f) {
+  df <- readr::read_tsv(f, show_col_types = FALSE)
+  df$group <- get_group(f)
+  df
+})
+
+df <- do.call(rbind, data_list)
+
+p <- ggplot(df, aes(x = length, y = mean_quality, color = group, shape = group)) +
+  geom_point(alpha = 0.4) +
+  labs(x = "Read length", y = "Mean quality score", color = "Group", shape = "Group") +
+  theme_minimal()
+
+ggsave(output_png, plot = p, width = 6, height = 4, units = "in")
+
+message("Plot saved to: ", output_png)
+cat(output_png, "\n")

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -57,9 +57,12 @@ fi
 # Paso 3: filtrado por calidad y longitud
 INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
 
-# Generar gráfico de calidad vs longitud
-# Se captura solo la última línea para obtener la ruta del archivo
-PLOT_FILE=$(Rscript scripts/plot_quality_vs_length.R "$WORK_DIR" | tail -n 1)
+# Generar gráfico de calidad vs longitud para múltiples etapas
+# Se captura solo la última línea para obtener la ruta del archivo generado
+PLOT_FILE=$(Rscript scripts/plot_quality_vs_length_multi.R \
+    "$FILTER_DIR/read_quality_vs_length.png" \
+    $PROCESSED_DIR/*_processed_stats.tsv \
+    $FILTER_DIR/*_filtered_stats.tsv | tail -n 1)
 
 conda activate clipon-ngs
 


### PR DESCRIPTION
## Summary
- Add `plot_quality_vs_length_multi.R` to plot read length vs. mean quality from multiple TSVs with grouping, colors, and shapes
- Update pipeline to invoke new plotting script after filtering and store output in the filter directory

## Testing
- `Rscript scripts/plot_quality_vs_length_multi.R test_plot.png sample_processed_stats.tsv sample_filtered_stats.tsv` *(fails: there is no package called ‘ggplot2’)*
- `Rscript -e 'install.packages(c("ggplot2","readr"), repos="https://cloud.r-project.org")'` *(fails: packages ‘ggplot2’, ‘readr’ are not available for this version of R)*
- `bash scripts/test_envs.sh` *(fails: Conda no se encontró en el sistema)*

------
https://chatgpt.com/codex/tasks/task_b_689ac8d8faa08321a40251250d330bc8