### PR TITLE
Ensure master consensus file is truncated before aggregation

### DIFF
--- a/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -22,6 +22,7 @@ mkdir -p "$DIR_SALIDA"
 
 # Archivo maestro que contendrá todas las secuencias con el identificador de experimento
 archivo_maestro="$DIR_SALIDA/consensos_todos.fasta"
+> "$archivo_maestro"
 
 # Inicializar una variable para verificar si se han procesado secuencias
 se_agregaron_secuencias=false


### PR DESCRIPTION
## Summary
- truncate `consensos_todos.fasta` before appending cluster sequences to avoid duplicate entries across runs

## Testing
- `bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh "$BASE_DIR" "$OUTPUT_DIR"`
- `bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh "$BASE_DIR" "$OUTPUT_DIR"`
- `cmp /tmp/consensos_run1.fasta "$OUTPUT_DIR/consensos_todos.fasta" && echo 'files are identical'`


------
https://chatgpt.com/codex/tasks/task_b_689accf202e08321990e64e94c2bedec