### PR TITLE
Procesar solo archivos consenso en unificación de clusters

### DIFF
--- a/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -43,7 +43,7 @@ for carpeta in "$BASE_DIR"/*; do
     > "$archivo_salida"
 
     # Unificar los archivos .fasta dentro de la carpeta y modificar los IDs
-    for fasta in "$carpeta"/*.fasta; do
+    for fasta in "$carpeta"/*consensus.fasta; do
       if [ -f "$fasta" ]; then
         awk -v id="$identificador" '/^>/ {print $0 "_" id} !/^>/ {print $0}' "$fasta" >> "$archivo_salida"
       fi


### PR DESCRIPTION
## Resumen
- Modifica el script de unificación para iterar únicamente sobre archivos `*consensus.fasta` dentro de cada carpeta.

## Pruebas
- Ejecutado `OUTPUT_DIR=/tmp/output BASE_DIR=/tmp/test_base ./scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh` con datos de ejemplo.

------
https://chatgpt.com/codex/tasks/task_b_689b764cc2288321b636633f80e88b3d