### PR TITLE
Check Rscript before plotting and document R dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Las rutas de entrada y salida también pueden configurarse manualmente al invoca
 - Cutadapt
 - NanoFilt (debe estar instalado antes de ejecutar `scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`)
 - QIIME2
+- R (opcional, necesario para generar el gráfico de calidad vs longitud; puede instalarse con `sudo apt install r-base`)
 - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para enviar notificaciones por correo)
 
 ## Ejemplos de ejecución

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -59,10 +59,15 @@ INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts
 
 # Generar gráfico de calidad vs longitud para múltiples etapas
 # Se captura solo la última línea para obtener la ruta del archivo generado
-PLOT_FILE=$(Rscript scripts/plot_quality_vs_length_multi.R \
-    "$FILTER_DIR/read_quality_vs_length.png" \
-    $PROCESSED_DIR/*_processed_stats.tsv \
-    $FILTER_DIR/*_filtered_stats.tsv | tail -n 1)
+if command -v Rscript >/dev/null 2>&1; then
+    PLOT_FILE=$(Rscript scripts/plot_quality_vs_length_multi.R \
+        "$FILTER_DIR/read_quality_vs_length.png" \
+        "$PROCESSED_DIR"/*_processed_stats.tsv \
+        "$FILTER_DIR"/*_filtered_stats.tsv | tail -n 1)
+else
+    echo "Rscript no encontrado; omitiendo la generación del gráfico. Instale R, por ejemplo: 'sudo apt install r-base'."
+    PLOT_FILE="N/A"
+fi
 
 conda activate clipon-ngs
 


### PR DESCRIPTION
## Summary
- Skip plot generation if `Rscript` isn't available and advise how to install R
- Mention optional R dependency for quality plots in README

## Testing
- `bash -n scripts/run_clipon_pipeline.sh`
- `shellcheck scripts/run_clipon_pipeline.sh`

------
https://chatgpt.com/codex/tasks/task_b_689b7ad55c8c8321b18dfeae6415acdf