### PR TITLE
feat: add conda environment installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,23 @@ Así evita implementar herramientas duplicadas para esta tarea.
 
 ## Entornos Conda
 
-El repositorio incluye tres archivos de entorno en `envs/` para mantener
-pequeñas dependencias por etapa.
+El repositorio incluye archivos de entorno en `envs/` y un asistente para instalarlos.
 
-```text
-envs/clipon-prep.yml   # QC y recorte
-envs/clipon-qiime.yml  # clustering con VSEARCH y clasificación
-envs/clipon-ngs.yml    # pipeline con NGSpeciesID
+Para crear los entornos automáticamente ejecute:
+
+```bash
+./scripts/install_envs.sh
 ```
 
-Cree cada entorno con `mamba` (o `conda` si no utiliza mamba):
+El script verifica que `conda` esté disponible (instala Miniconda si es necesario) y crea los entornos que falten a partir de los YAML.
+
+### Descripción de los entornos
+
+- `clipon-prep`: control de calidad y recorte inicial.
+- `clipon-qiime`: clustering y clasificación con QIIME 2 y VSEARCH.
+- `clipon-ngs`: generación de consensos con NGSpeciesID.
+
+También puede crearlos manualmente con `mamba` (o `conda`):
 
 ```bash
 mamba env create -f envs/clipon-prep.yml
@@ -81,21 +88,14 @@ mamba env create -f envs/clipon-qiime.yml
 mamba env create -f envs/clipon-ngs.yml
 ```
 
-Si alguno de los archivos de `envs/` cambia y el entorno ya existe,
-reconstrúyalo con:
+Si alguno de los archivos de `envs/` cambia y el entorno ya existe, reconstrúyalo con:
 
 ```bash
 conda env update -f <archivo>.yml
 ```
 
-Reemplace `<archivo>` por el nombre del archivo YAML correspondiente.
+Active cada entorno solo la primera vez para instalarlo. El script `run_clipon_pipeline.sh` se encarga de activar el entorno adecuado en cada etapa, por lo que puede ejecutarse sin activar nada manualmente. Si desea ejecutar las etapas por separado, active el entorno correspondiente de forma manual. El entorno `clipon-qiime` también se reutiliza para el módulo **Classifier** y contiene `msmtp` para habilitar las notificaciones por correo.
 
-Active cada entorno solo la primera vez para instalarlo.  El script
-`run_clipon_pipeline.sh` se encarga de activar el entorno adecuado en cada
-etapa, por lo que puede ejecutarse sin activar nada manualmente.  Si desea
-ejecutar las etapas por separado, active el entorno correspondiente de forma
-manual.  El entorno `clipon-qiime` también se reutiliza para el módulo
-**Classifier** y contiene `msmtp` para habilitar las notificaciones por correo.
 
 ### Clustering con NGSpeciesID
 ```bash

--- a/scripts/install_envs.sh
+++ b/scripts/install_envs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to install ClipON conda environments
+# Checks for conda availability, installs Miniconda if requested,
+# and creates missing environments from the YAML files in ../envs
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_DIR="$SCRIPT_DIR/../envs"
+
+# Ensure conda is available, install Miniconda if missing
+if ! command -v conda >/dev/null 2>&1; then
+  read -rp "Conda no se encontró. ¿Desea instalar Miniconda? [y/N] " resp
+  if [[ $resp =~ ^[Yy]$ ]]; then
+    installer=/tmp/miniconda.sh
+    echo "Descargando Miniconda..."
+    if ! wget -O "$installer" https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh; then
+      echo "No se pudo descargar Miniconda" >&2
+      exit 1
+    fi
+    echo "Instalando Miniconda en $HOME/miniconda..."
+    if ! bash "$installer" -b -p "$HOME/miniconda"; then
+      echo "La instalación de Miniconda falló" >&2
+      exit 1
+    fi
+    rm -f "$installer"
+    # Habilitar conda en la sesión actual
+    if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
+      . "$HOME/miniconda/etc/profile.d/conda.sh"
+    else
+      export PATH="$HOME/miniconda/bin:$PATH"
+    fi
+  else
+    echo "Abortando instalación de entornos."
+    exit 1
+  fi
+fi
+
+# Iterate over YAML files and create missing environments
+for yml in "$ENV_DIR"/*.yml; do
+  env_name="$(basename "$yml" .yml)"
+  if conda env list | awk '{print $1}' | grep -Fxq "$env_name"; then
+    echo "El entorno '$env_name' ya existe."
+  else
+    read -rp "El entorno '$env_name' no existe. ¿Desea crearlo? [y/N] " ans
+    if [[ $ans =~ ^[Yy]$ ]]; then
+      conda env create -f "$yml"
+    else
+      echo "Omitiendo '$env_name'."
+    fi
+  fi
+  echo
+done

--- a/scripts/test_envs.sh
+++ b/scripts/test_envs.sh
@@ -3,9 +3,15 @@
 # Script to verify required ClipON conda environments are present
 # and can run a simple command.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Check that conda is available
-if ! command -v conda >/dev/null; then
+if ! command -v conda >/dev/null 2>&1; then
   echo "Conda no se encontró en el sistema."
+  read -rp "¿Desea ejecutar $SCRIPT_DIR/install_envs.sh para instalarlo? [y/N] " resp
+  if [[ $resp =~ ^[Yy]$ ]]; then
+    "$SCRIPT_DIR/install_envs.sh"
+  fi
   exit 1
 fi
 
@@ -16,6 +22,8 @@ declare -A ENV_CHECKS=(
   [clipon-qiime]="qiime --help"
   [clipon-ngs]="minimap2 --version"
 )
+
+missing_envs=()
 
 for env in "${!ENV_CHECKS[@]}"; do
   echo "Comprobando entorno '$env'..."
@@ -28,7 +36,16 @@ for env in "${!ENV_CHECKS[@]}"; do
     fi
   else
     echo "  - Entorno no encontrado"
+    missing_envs+=("$env")
   fi
   echo
 
 done
+
+if (( ${#missing_envs[@]} )); then
+  echo "Entornos faltantes: ${missing_envs[*]}"
+  read -rp "¿Desea ejecutar $SCRIPT_DIR/install_envs.sh para instalarlos? [y/N] " answer
+  if [[ $answer =~ ^[Yy]$ ]]; then
+    "$SCRIPT_DIR/install_envs.sh"
+  fi
+fi


### PR DESCRIPTION
## Summary
- add `install_envs.sh` to install Miniconda and create ClipON conda envs
- have `test_envs.sh` offer to run the installer when envs are missing
- document environment installer and usage in `README.md`

## Testing
- `bash scripts/test_envs.sh` *(fails: Conda no se encontró...)*
- `bash scripts/install_envs.sh` *(fails: Conda no se encontró...)*

------
https://chatgpt.com/codex/tasks/task_b_68a090d7c2b883218acc75821bd74299