### PR TITLE
Add R dependencies to clipon-prep environment

### DIFF
--- a/envs/clipon-prep.yml
+++ b/envs/clipon-prep.yml
@@ -10,3 +10,7 @@ dependencies:
   - pigz=2.8
   - pandas=2.2.2
   - matplotlib=3.8.4
+  - r-base
+  - r-ggplot2
+  - r-readr
+  - r-rcolorbrewer


### PR DESCRIPTION
## Summary
- include r-base and R plotting/read packages in clipon-prep env

## Testing
- `conda env update -f envs/clipon-prep.yml` *(fails: command not found)*
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a09359e60483219c8d4953efe026b5