### PR TITLE
Use full folder name for consensus identifiers

### DIFF
--- a/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -33,8 +33,8 @@ for carpeta in "$BASE_DIR"/*; do
     # Extraer el nombre de la carpeta
     nombre_carpeta=$(basename "$carpeta")
 
-    # Extraer la parte entre el primer y segundo "_"
-    identificador=$(echo "$nombre_carpeta" | cut -d'_' -f2)
+    # Usar el nombre completo de la carpeta como identificador
+    identificador="$nombre_carpeta"
 
     # Archivo de salida individual
     archivo_salida="$DIR_SALIDA/consensos_${identificador}.fasta"


### PR DESCRIPTION
## Summary
- Preserve the complete directory name when generating unified consensus FASTA files so downstream results retain the original sample identifier.

## Testing
- `BASE_DIR=/tmp/test_clusters OUTPUT_DIR=/tmp/test_unified bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh`
- `bash scripts/run_clipon_pipeline.sh /tmp/test_fastq /tmp/pipeline_output` *(fails: `conda` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0956ba3508321b4818cae42420d7b