### PR TITLE
Normalize cleaned stats files in summary

### DIFF
--- a/scripts/summarize_read_counts.py
+++ b/scripts/summarize_read_counts.py
@@ -39,14 +39,22 @@ counts = defaultdict(lambda: {"raw": 0, "processed": 0, "filtered": 0})
 
 for stage, pattern in patterns.items():
     for path in glob.glob(os.path.join(base_dir, "**", pattern), recursive=True):
-        sample = re.sub(rf"_{stage}_stats\.tsv$", "", os.path.basename(path))
+        file_name = os.path.basename(path)
+        sample = re.sub(rf"_{stage}_stats\.tsv$", "", file_name)
+        base = re.sub(r"^cleaned_", "", sample)
+
+        # Skip duplicate "cleaned_" files for stages other than "filtered"
+        if sample.startswith("cleaned_") and stage != "filtered":
+            continue
+
         try:
             with open(path) as fh:
                 num = sum(1 for _ in fh) - 1  # subtract header
         except OSError as e:
             print(f"Warning: could not read {path}: {e}", file=sys.stderr)
             num = 0
-        counts[sample][stage] = num
+
+        counts[base][stage] = num
 
 print("archivo\traw\tprocessed\tfiltered")
 for sample in sorted(counts):

--- a/tests/test_summarize_read_counts.py
+++ b/tests/test_summarize_read_counts.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_stats(path, n):
+    content = "header\n" + "\n".join(f"r{i}\tdata" for i in range(n)) + "\n"
+    path.write_text(content)
+
+
+def test_cleaned_files_update_filtered(tmp_path):
+    write_stats(tmp_path / "CAV_37C01C_raw_stats.tsv", 2)
+    write_stats(tmp_path / "SAV_926008_raw_stats.tsv", 2)
+    write_stats(tmp_path / "cleaned_CAV_37C01C_filtered_stats.tsv", 3)
+    write_stats(tmp_path / "cleaned_SAV_926008_filtered_stats.tsv", 4)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "summarize_read_counts.py"
+    result = subprocess.run(
+        [sys.executable, str(script), str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = result.stdout.strip().splitlines()
+    table = {}
+    for line in lines[1:]:
+        sample, raw, processed, filtered = line.split("\t")
+        table[sample] = {
+            "raw": int(raw),
+            "processed": int(processed),
+            "filtered": int(filtered),
+        }
+
+    assert table["CAV_37C01C"]["raw"] == 2
+    assert table["CAV_37C01C"]["filtered"] == 3
+    assert table["SAV_926008"]["raw"] == 2
+    assert table["SAV_926008"]["filtered"] == 4
+    assert "cleaned_CAV_37C01C" not in table
+    assert "cleaned_SAV_926008" not in table


### PR DESCRIPTION
## Summary
- Normalize filenames in `summarize_read_counts.py` by stripping `cleaned_` prefix
- Update summary logic to merge cleaned stats into existing sample rows and skip duplicates
- Add pytest verifying cleaned stats update correct rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a09537bad48321b19dd8a0ad744aef