### PR TITLE
Add taxon bar plot generator to pipeline

### DIFF
--- a/scripts/plot_taxon_bar.R
+++ b/scripts/plot_taxon_bar.R
@@ -1,0 +1,40 @@
+#!/usr/bin/env Rscript
+
+# Genera un gráfico de barras apiladas por taxón para cada muestra
+# Uso: Rscript scripts/plot_taxon_bar.R <archivo_taxonomia.tsv> <salida.png>
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+  stop("Se requieren los parámetros: <archivo_taxonomia.tsv> <salida.png>")
+}
+
+input_file <- args[1]
+output_file <- args[2]
+
+suppressPackageStartupMessages({
+  library(readr)
+  library(dplyr)
+  library(ggplot2)
+})
+
+# Leer el archivo de taxonomía
+# Se espera que contenga al menos las columnas: Sample, Taxon y Reads
+data <- read_tsv(input_file, show_col_types = FALSE)
+
+plot_data <- data %>%
+  select(Sample, Taxon, Reads) %>%
+  group_by(Sample, Taxon) %>%
+  summarise(Reads = sum(Reads), .groups = "drop") %>%
+  group_by(Sample) %>%
+  mutate(Percent = Reads / sum(Reads))
+
+p <- ggplot(plot_data, aes(x = Sample, y = Percent, fill = Taxon)) +
+  geom_col() +
+  ylab("Proporción de lecturas") +
+  xlab("Muestra") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+
+ggsave(output_file, p, width = 8, height = 5, dpi = 300)
+
+cat(output_file, "\n")

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -105,6 +105,14 @@ run_step 7 clipon-qiime bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_D
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
+TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" | tail -n 1)
+read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
+if [[ $OPEN_TAX_PLOT =~ ^[Yy]$ ]]; then
+    xdg-open "$TAX_PLOT_FILE"
+else
+    echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
+fi
+
 echo -e "\nResumen de lecturas por etapa:"
 python3 scripts/summarize_read_counts.py "$WORK_DIR"
 echo "Pipeline completado. Resultados en: $WORK_DIR"


### PR DESCRIPTION
## Summary
- add `plot_taxon_bar.R` to visualize taxonomy per sample
- extend `run_clipon_pipeline.sh` to generate taxon stacked bar and optionally open it

## Testing
- `pytest -q`
- `Rscript scripts/plot_taxon_bar.R /tmp/test_taxonomy.tsv /tmp/test_plot.png`


------
https://chatgpt.com/codex/tasks/task_b_68a09e95991883218d9d6d415f0c68af