### PR TITLE
Handle Rscript errors and log output

### DIFF
--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -92,7 +92,10 @@ if command -v Rscript >/dev/null 2>&1; then
     PLOT_FILE=$(Rscript scripts/plot_quality_vs_length_multi.R \
         "$FILTER_DIR/read_quality_vs_length.png" \
         "$PROCESSED_DIR"/*_processed_stats.tsv \
-        "$FILTER_DIR"/*_filtered_stats.tsv | tail -n 1)
+        "$FILTER_DIR"/*_filtered_stats.tsv 2>&1 | tee "$WORK_DIR/r_plot.log" | tail -n 1) || {
+            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+            PLOT_FILE="N/A"
+        }
 else
     echo "Rscript no encontrado; omitiendo la generación del gráfico. Instale R, por ejemplo: 'sudo apt install r-base'."
     PLOT_FILE="N/A"


### PR DESCRIPTION
## Summary
- Log Rscript output during pipeline plotting step and append an error message if the command fails
- Continue pipeline by setting `PLOT_FILE` to `N/A` when Rscript execution fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a0a0e2aa1883218f951ebb905059e4