### PR TITLE
test_envs: verifica paquetes R en clipon-prep

### DIFF
--- a/scripts/test_envs.sh
+++ b/scripts/test_envs.sh
@@ -34,6 +34,12 @@ for env in "${!ENV_CHECKS[@]}"; do
     else
       echo "  - Falló al ejecutar '$cmd'"
     fi
+    if [[ "$env" == "clipon-prep" ]]; then
+      if ! conda run -n clipon-prep \
+        Rscript -e "quit(status = !all(c('ggplot2','readr') %in% rownames(installed.packages())))" >/dev/null 2>&1; then
+        echo "Instale los paquetes de R necesarios (ggplot2, readr) en el entorno clipon-prep."
+      fi
+    fi
   else
     echo "  - Entorno no encontrado"
     missing_envs+=("$env")


### PR DESCRIPTION
## Summary
- Añade una comprobación en `clipon-prep` para asegurar que los paquetes de R `ggplot2` y `readr` están instalados.

## Testing
- `bash scripts/test_envs.sh` *(falla: Conda no se encontró en el sistema)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ad825d1c8321bf5712ea34ac3923