### PR TITLE
Make points opaque and smaller in quality-length plot

### DIFF
--- a/scripts/plot_quality_vs_length_multi.R
+++ b/scripts/plot_quality_vs_length_multi.R
@@ -33,7 +33,7 @@ data_list <- lapply(input_files, function(f) {
 df <- do.call(rbind, data_list)
 
 p <- ggplot(df, aes(x = length, y = mean_quality, color = group, shape = group)) +
-  geom_point(alpha = 0.4) +
+  geom_point(size = 0.2, alpha = 1) +
   labs(x = "Read length", y = "Mean quality score", color = "Group", shape = "Group") +
   theme_minimal()
 


### PR DESCRIPTION
## Summary
- Draw plot points without transparency and with a small size to make quality vs length plot clearer

## Testing
- `Rscript scripts/plot_quality_vs_length_multi.R /tmp/test_output.png /tmp/processed_stats.tsv /tmp/filtered_stats.tsv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0b2e0d5d48321be5485492770dac9