### PR TITLE
Ensure pipeline paths are normalized and fail without master file

### DIFF
--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -31,6 +31,7 @@ if [[ $run_mode =~ ^[Rr]$ ]]; then
     MODE="resume"
     while true; do
         read -rp "Ingrese el directorio de trabajo existente: " WORK_DIR
+        WORK_DIR="${WORK_DIR%/}"
         if [ ! -d "$WORK_DIR" ]; then
             echo "El directorio '$WORK_DIR' no existe o no es accesible. Intente nuevamente."
             continue
@@ -47,6 +48,7 @@ fi
 
 while true; do
     read -rp "Ingrese el directorio que contiene los archivos FASTQ: " INPUT_DIR
+    INPUT_DIR="${INPUT_DIR%/}"
     if [ ! -d "$INPUT_DIR" ]; then
         echo "El directorio '$INPUT_DIR' no existe o no es accesible. Intente nuevamente."
         continue
@@ -63,6 +65,7 @@ done
 
 if [ "$MODE" = "new" ]; then
     read -rp "Ingrese el directorio de trabajo donde se guardarán los resultados: " WORK_DIR
+    WORK_DIR="${WORK_DIR%/}"
     mkdir -p "$WORK_DIR"
 fi
 

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -24,8 +24,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-INPUT_DIR="$1"
-WORK_DIR="$2"
+INPUT_DIR="${1%/}"
+WORK_DIR="${2%/}"
 
 # Configuración opcional para el recorte
 SKIP_TRIM="${SKIP_TRIM:-0}"
@@ -103,6 +103,12 @@ fi
 
 run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/De2_A2.5_NGSpecies_Clustering.sh
 run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+
+if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
+    echo "No se creó el archivo maestro de consensos. Abortando pipeline."
+    exit 1
+fi
+
 run_step 6 clipon-qiime classify_reads
 run_step 7 clipon-qiime bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
 


### PR DESCRIPTION
## Summary
- Strip trailing slashes from input and work directories to avoid `//` in paths
- Stop the pipeline with a clear message when `consensos_todos.fasta` is missing

## Testing
- `shellcheck scripts/run_clipon_interactive.sh scripts/run_clipon_pipeline.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0b4b4d3a88321aee75066ffd2b1a7