### PR TITLE
Generate taxon stacked bar plot and integrate with pipeline

### DIFF
--- a/scripts/plot_taxon_bar.R
+++ b/scripts/plot_taxon_bar.R
@@ -37,4 +37,6 @@ p <- ggplot(plot_data, aes(x = Sample, y = Percent, fill = Taxon)) +
 
 ggsave(output_file, p, width = 8, height = 5, dpi = 300)
 
-cat(output_file, "\n")
+# Imprimir la ruta absoluta del archivo generado
+output_path <- normalizePath(output_file)
+cat(output_path, "\n")

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -108,12 +108,22 @@ run_step 7 clipon-qiime bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_D
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
-TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" | tail -n 1)
-read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
-if [[ $OPEN_TAX_PLOT =~ ^[Yy]$ ]]; then
-    xdg-open "$TAX_PLOT_FILE"
+TAX_PLOT_FILE="N/A"
+if command -v Rscript >/dev/null 2>&1; then
+    TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R \
+        "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | tee -a "$WORK_DIR/r_plot.log" | tail -n 1) || {
+            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+            TAX_PLOT_FILE="N/A"
+        }
+    read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
+    if [[ $OPEN_TAX_PLOT =~ ^[Yy]$ && -f "$TAX_PLOT_FILE" ]]; then
+        xdg-open "$TAX_PLOT_FILE"
+    else
+        echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
+    fi
 else
-    echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
+    echo "Rscript no encontrado; omitiendo la generación del gráfico de taxones. Instale R, por ejemplo: 'sudo apt install r-base'."
 fi
 
 echo -e "\nResumen de lecturas por etapa:"


### PR DESCRIPTION
## Summary
- produce taxon stacked bar chart with readr/dplyr/ggplot2 and print absolute path
- run plot generation at end of pipeline with optional xdg-open

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0adab6bc48321872243b22dbb9dc9