### PR TITLE
feat: integrate pipeline into interactive script

### DIFF
--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Script interactivo para ejecutar el pipeline de ClipON paso a paso
 # Nota: la extracción de longitudes y calidades por lectura ya se realiza con
@@ -125,7 +125,125 @@ fi
 
 echo "Iniciando pipeline..."
 
-SKIP_TRIM="$SKIP_TRIM" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" \
-    scripts/run_clipon_pipeline.sh "$INPUT_DIR" "$WORK_DIR"
+source "$(conda info --base)/etc/profile.d/conda.sh"
+RESUME_STEP="${RESUME_STEP:-1}"
 
-echo "Ejecución finalizada. Resultados en: $WORK_DIR"
+PROCESSED_DIR="$WORK_DIR/1_processed"
+TRIM_DIR="$WORK_DIR/2_trimmed"
+FILTER_DIR="$WORK_DIR/3_filtered"
+CLUSTER_DIR="$WORK_DIR/4_clustered"
+UNIFIED_DIR="$WORK_DIR/5_unified"
+LOG_FILE="$FILTER_DIR/nanofilt.log"
+
+mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR"
+
+run_step() {
+    local step="$1"
+    local env="$2"
+    shift 2
+    local cmd="$*"
+
+    if [ "$RESUME_STEP" -gt "$step" ]; then
+        echo "Saltando paso $step; RESUME_STEP=$RESUME_STEP"
+        return 0
+    fi
+
+    conda activate "$env"
+    eval "$cmd"
+    touch "$WORK_DIR/.step${step}_done"
+}
+
+print_section() {
+    echo "========================================================="
+    echo "$1"
+    echo "========================================================="
+}
+
+trim_reads() {
+    if [ "$SKIP_TRIM" -eq 1 ]; then
+        echo "Omitiendo recorte de secuencias."
+        cp "$PROCESSED_DIR"/*.fastq "$TRIM_DIR"/
+    else
+        INPUT_DIR="$PROCESSED_DIR" OUTPUT_DIR="$TRIM_DIR" TRIM_FRONT="$TRIM_FRONT" TRIM_BACK="$TRIM_BACK" \
+            bash scripts/De1_A1.5_Trim_Fastq.sh
+    fi
+}
+
+classify_reads() {
+    if [[ -z "${BLAST_DB:-}" || -z "${TAXONOMY_DB:-}" ]]; then
+        echo "Advertencia: BLAST_DB o TAXONOMY_DB no están definidos. Omitiendo clasificación."
+        return 0
+    fi
+    bash scripts/De3_A4_Classify_NGS.sh \
+        "$UNIFIED_DIR/consensos_todos.fasta" \
+        "$UNIFIED_DIR" \
+        "$BLAST_DB" \
+        "$TAXONOMY_DB"
+    echo "Clasificación finalizada. Revise $UNIFIED_DIR/MaxAc_5"
+}
+
+print_section "Paso 1: Procesamiento inicial de FASTQ"
+run_step 1 clipon-prep INPUT_DIR="$INPUT_DIR" OUTPUT_DIR="$PROCESSED_DIR" bash scripts/De0_A1_Process_Fastq.4_SeqKit.sh
+
+print_section "Paso 2: Recorte de secuencias"
+run_step 2 clipon-prep trim_reads
+
+print_section "Paso 3: Filtrado con NanoFilt"
+run_step 3 clipon-prep INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+
+print_section "Gráfico de calidad vs longitud"
+if command -v Rscript >/dev/null 2>&1; then
+    PLOT_FILE=$(Rscript scripts/plot_quality_vs_length_multi.R \
+        "$FILTER_DIR/read_quality_vs_length.png" \
+        "$PROCESSED_DIR"/*_processed_stats.tsv \
+        "$FILTER_DIR"/*_filtered_stats.tsv 2>&1 | tee "$WORK_DIR/r_plot.log" | tail -n 1) || {
+            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+            PLOT_FILE="N/A"
+        }
+else
+    echo "Rscript no encontrado; omitiendo la generación del gráfico. Instale R, por ejemplo: 'sudo apt install r-base'."
+    PLOT_FILE="N/A"
+fi
+
+print_section "Paso 4: Clustering de NGSpecies"
+run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/De2_A2.5_NGSpecies_Clustering.sh
+
+print_section "Paso 5: Unificación de clusters"
+run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+
+if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
+    echo "No se creó el archivo maestro de consensos. Abortando pipeline."
+    exit 1
+fi
+
+print_section "Paso 6: Clasificación taxonómica"
+run_step 6 clipon-qiime classify_reads
+
+print_section "Paso 7: Exportación de clasificación"
+run_step 7 clipon-qiime bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
+
+echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
+
+print_section "Gráfico de taxones"
+TAX_PLOT_FILE="N/A"
+if command -v Rscript >/dev/null 2>&1; then
+    TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R \
+        "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | tee -a "$WORK_DIR/r_plot.log" | tail -n 1) || {
+            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+            TAX_PLOT_FILE="N/A"
+        }
+    read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
+    if [[ $OPEN_TAX_PLOT =~ ^[Yy]$ && -f "$TAX_PLOT_FILE" ]]; then
+        xdg-open "$TAX_PLOT_FILE"
+    else
+        echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
+    fi
+else
+    echo "Rscript no encontrado; omitiendo la generación del gráfico de taxones. Instale R, por ejemplo: 'sudo apt install r-base'."
+fi
+
+print_section "Resumen final"
+python3 scripts/summarize_read_counts.py "$WORK_DIR"
+echo "Pipeline completado. Resultados en: $WORK_DIR"
+echo "Gráfico de calidad vs longitud: $PLOT_FILE"


### PR DESCRIPTION
## Summary
- Make `run_clipon_interactive.sh` a standalone pipeline that initializes conda, defines step helpers, and executes each processing stage directly
- Add section headers and separators for each pipeline step and report generation

## Testing
- `scripts/test_envs.sh` *(fails: Conda no se encontró en el sistema.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0baab194883219e581f7ee3db307e