### PR TITLE
Narrow glob for consensus fasta files in cluster unification script

### DIFF
--- a/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -44,10 +44,9 @@ for carpeta in "$BASE_DIR"/*; do
     > "$archivo_salida"
 
     # Unificar los archivos .fasta dentro de la carpeta y modificar los IDs
-    for fasta in "$carpeta"/*consensus.fasta; do
-      if [ -f "$fasta" ]; then
-        awk -v id="$identificador" '/^>/ {print $0 "_" id} !/^>/ {print $0}' "$fasta" >> "$archivo_salida"
-      fi
+    for fasta in "$carpeta"/consensus_reference_*.fasta; do
+      [ -f "$fasta" ] || continue
+      awk -v id="$identificador" '/^>/ {print $0 "_" id} !/^>/ {print $0}' "$fasta" >> "$archivo_salida"
     done
 
     # Verificar si el archivo individual no está vacío


### PR DESCRIPTION
## Summary
- Ensure cluster unification script only processes `consensus_reference_*.fasta` files
- Skip loop body when no matching consensus files are present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0c0a39fb88321a36bab466a04abba