### PR TITLE
Add default trimming value prompts in interactive script

### DIFF
--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -71,14 +71,25 @@ fi
 
 # Paso opcional de recorte de secuencias
 read -rp "¿Desea recortar las secuencias con cutadapt? (y/n) " do_trim
+DEFAULT_TRIM_FRONT=0
+DEFAULT_TRIM_BACK=0
 if [[ $do_trim =~ ^[Yy]$ ]]; then
-    read -rp "Número de bases a recortar del inicio: " TRIM_FRONT
-    read -rp "Número de bases a recortar del final: " TRIM_BACK
+    echo "Valores estándar: inicio ${DEFAULT_TRIM_FRONT} bases, final ${DEFAULT_TRIM_BACK} bases."
+    read -p "¿Desea mantener estos valores? (y/n) " keep_defaults
+    if [[ $keep_defaults =~ ^[Yy]$ ]]; then
+        TRIM_FRONT=$DEFAULT_TRIM_FRONT
+        TRIM_BACK=$DEFAULT_TRIM_BACK
+    else
+        read -p "Número de bases a recortar del inicio [${DEFAULT_TRIM_FRONT}]: " TRIM_FRONT
+        TRIM_FRONT=${TRIM_FRONT:-$DEFAULT_TRIM_FRONT}
+        read -p "Número de bases a recortar del final [${DEFAULT_TRIM_BACK}]: " TRIM_BACK
+        TRIM_BACK=${TRIM_BACK:-$DEFAULT_TRIM_BACK}
+    fi
     SKIP_TRIM=0
 else
     SKIP_TRIM=1
-    TRIM_FRONT=0
-    TRIM_BACK=0
+    TRIM_FRONT=$DEFAULT_TRIM_FRONT
+    TRIM_BACK=$DEFAULT_TRIM_BACK
 fi
 
 # Solicitar rutas para bases de datos necesarias


### PR DESCRIPTION
## Summary
- Show standard trim values and allow keeping or modifying them using `read -p`
- Keep resulting TRIM_FRONT/BACK values propagated to `De1_A1.5_Trim_Fastq.sh`

## Testing
- `bash -n scripts/run_clipon_interactive.sh`
- `pytest tests/test_summarize_read_counts.py`

------
https://chatgpt.com/codex/tasks/task_b_68a0cd9fa3e08321a8ad9440c8e8d051