### PR TITLE
Allow configuring NanoFilt parameters in interactive pipeline

### DIFF
--- a/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+++ b/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
@@ -21,6 +21,11 @@ input_dir="${INPUT_DIR:-$1}"
 output_dir="${OUTPUT_DIR:-$2}"
 log_file="${LOG_FILE:-$3}"
 
+# Parámetros de filtrado con valores por defecto
+MIN_LEN="${MIN_LEN:-650}"
+MAX_LEN="${MAX_LEN:-750}"
+MIN_QUAL="${MIN_QUAL:-10}"
+
 if [ -z "$input_dir" ] || [ -z "$output_dir" ] || [ -z "$log_file" ]; then
     echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> LOG_FILE=<archivo log> $0"
     echo "   o: $0 <dir entrada> <dir salida> <archivo log>"
@@ -40,8 +45,8 @@ for file in "$input_dir"/*.fastq; do
 
     # Ejecutar NanoFilt y guardar en formato FASTQ
     echo "Filtrando $file..." >> "$log_file"
-    output_file="$output_dir/${base_name}_Filt650_750_Q10.fastq"
-    cat "$file" | NanoFilt -l 650 --maxlength 750 -q 10 > "$output_file" 2>> "$log_file"
+    output_file="$output_dir/${base_name}_Filt${MIN_LEN}_${MAX_LEN}_Q${MIN_QUAL}.fastq"
+    cat "$file" | NanoFilt -l "$MIN_LEN" --maxlength "$MAX_LEN" -q "$MIN_QUAL" > "$output_file" 2>> "$log_file"
 
     # Verificar si el proceso fue exitoso
     if [ $? -eq 0 ]; then

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -199,8 +199,26 @@ run_step 1 clipon-prep INPUT_DIR="$INPUT_DIR" OUTPUT_DIR="$PROCESSED_DIR" bash s
 print_section "Paso 2: Recorte de secuencias"
 run_step 2 clipon-prep trim_reads
 
+DEFAULT_MIN_LEN=650
+DEFAULT_MAX_LEN=750
+DEFAULT_MIN_QUAL=10
+echo "Valores estándar: longitud mínima ${DEFAULT_MIN_LEN} bp, máxima ${DEFAULT_MAX_LEN} bp, calidad mínima ${DEFAULT_MIN_QUAL}" 
+read -p "¿Desea modificar estos valores? (y/n) " modify_filters
+if [[ $modify_filters =~ ^[Yy]$ ]]; then
+    read -p "Longitud mínima [${DEFAULT_MIN_LEN}]: " MIN_LEN
+    MIN_LEN=${MIN_LEN:-$DEFAULT_MIN_LEN}
+    read -p "Longitud máxima [${DEFAULT_MAX_LEN}]: " MAX_LEN
+    MAX_LEN=${MAX_LEN:-$DEFAULT_MAX_LEN}
+    read -p "Calidad mínima [${DEFAULT_MIN_QUAL}]: " MIN_QUAL
+    MIN_QUAL=${MIN_QUAL:-$DEFAULT_MIN_QUAL}
+else
+    MIN_LEN=$DEFAULT_MIN_LEN
+    MAX_LEN=$DEFAULT_MAX_LEN
+    MIN_QUAL=$DEFAULT_MIN_QUAL
+fi
+
 print_section "Paso 3: Filtrado con NanoFilt"
-run_step 3 clipon-prep INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+run_step 3 clipon-prep MIN_LEN="$MIN_LEN" MAX_LEN="$MAX_LEN" MIN_QUAL="$MIN_QUAL" INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
 
 echo -e "\nResumen de lecturas tras filtrado:"
 python3 scripts/summarize_read_counts.py "$WORK_DIR"


### PR DESCRIPTION
## Summary
- Expose MIN_LEN, MAX_LEN, and MIN_QUAL parameters in NanoFilt filtering script with defaults 650/750/10
- Add interactive prompts to adjust filtering parameters in `run_clipon_interactive.sh` and pass them to NanoFilt

## Testing
- `bash -n scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`
- `bash -n scripts/run_clipon_interactive.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0cefe50808321a8a3d58d844fbcfe