### PR TITLE
chore: use env bash and strict mode in scripts

### DIFF
--- a/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
+++ b/scripts/De0_A1_Process_Fastq.4_SeqKit.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Verificar si seqkit está instalado
 if ! command -v seqkit &> /dev/null; then

--- a/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
+++ b/scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Chequeo si NanoFilt está instalado
 if ! command -v NanoFilt >/dev/null; then

--- a/scripts/De1_A1.5_Trim_Fastq.sh
+++ b/scripts/De1_A1.5_Trim_Fastq.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Chequeo si cutadapt está instalado
 if ! command -v cutadapt >/dev/null; then

--- a/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+++ b/scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Uso:
 #   BASE_DIR=/ruta/a/clustered OUTPUT_DIR=/ruta/a/unificado ./De2.5_A3_NGSpecies_Unificar_Clusters.sh

--- a/scripts/De2_A2.5_NGSpecies_Clustering.sh
+++ b/scripts/De2_A2.5_NGSpecies_Clustering.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Uso:
 #   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./De2_A2.5_NGSpecies_Clustering.sh

--- a/scripts/De2_A4_VSearch_ejecutador_combinaciones1.1.sh
+++ b/scripts/De2_A4_VSearch_ejecutador_combinaciones1.1.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Parámetros pasados por variables de entorno o argumentos
 manifest_file="${MANIFEST_FILE:-${1-}}"

--- a/scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh
+++ b/scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -e
-set -u
-set -o pipefail
 
 # Comprobar que las dependencias necesarias están instaladas
 if ! command -v qiime >/dev/null 2>&1; then

--- a/scripts/De3_A4_Classify_NGS.sh
+++ b/scripts/De3_A4_Classify_NGS.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Clasifica consensos con QIIME2 empleando el clasificador BLAST
 # Uso:

--- a/scripts/De3_A4_Export_Classification.sh
+++ b/scripts/De3_A4_Export_Classification.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Exporta archivos de clasificacion de QIIME2
 # Uso:

--- a/scripts/check_pipeline_status.sh
+++ b/scripts/check_pipeline_status.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
     echo "Uso: $0 <dir_trabajo>" >&2

--- a/scripts/generate_manifest.sh
+++ b/scripts/generate_manifest.sh
@@ -1,7 +1,5 @@
-#!/bin/bash
-set -e
-set -u
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'

--- a/scripts/install_envs.sh
+++ b/scripts/install_envs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Script to install ClipON conda environments
 # Checks for conda availability, installs Miniconda if requested,

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Función auxiliar para solicitar parámetros con un valor por defecto

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Wrapper para ejecutar la cadena completa de procesamiento de ClipON
 # Uso: ./run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
@@ -7,9 +8,6 @@
 # Para un gráfico avanzado de la calidad de lectura combine los TSV generados en cada etapa (collect_read_stats.py):
 # Rscript scripts/read_quality_poster.R "ruta/etapa1.tsv,ruta/etapa2.tsv" salida.png
 
-set -e
-set -u
-set -o pipefail
 
 # Determinar la raíz del repositorio y usar rutas relativas
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/test_envs.sh
+++ b/scripts/test_envs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Script to verify required ClipON conda environments are present
 # and can run a simple command.


### PR DESCRIPTION
## Summary
- replace direct `/bin/bash` shebangs in scripts with `/usr/bin/env bash`
- ensure each script enables `set -euo pipefail` for stricter execution

## Testing
- `shellcheck scripts/*.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0dc9691508321920b8ceecfbc3a1c