### PR TITLE
Add species read summary to interactive pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 4. **Clustering** – `NGSpeciesID` agrupa secuencias y genera consensos.
 5. **Unificación de clusters** – se combinan los consensos de distintos experimentos.
 6. **Clasificación opcional** – el script `scripts/De3_A4_Classify_NGS.sh` usa `qiime feature-classifier classify-consensus-blast` para asignar taxonomía a los consensos unificados.
-7. **Exportación de la clasificación** – `scripts/De3_A4_Export_Classification.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `MaxAc_5`.
+7. **Exportación de la clasificación** – `scripts/De3_A4_Export_Classification.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `MaxAc_5`. Además, crea `reads_per_species.tsv` con el número total de lecturas por especie y muestra.
 
 
 ## Uso rápido
@@ -22,7 +22,8 @@ Ejecuta todo el flujo con:
 El directorio `<dir_trabajo>/5_unified` contendrá los archivos de clasificación
 `taxonomy.qza` y `search_results.qza`. El paso de exportación generará copias en
 texto dentro de `5_unified/MaxAc_5`, incluyendo `taxonomy_with_sample.tsv` con
-las columnas adicionales *Reads* y *Sample*. Defina las variables de entorno
+las columnas adicionales *Reads* y *Sample* y `reads_per_species.tsv` con los
+conteos de lecturas por especie y muestra. Defina las variables de entorno
 `BLAST_DB` y `TAXONOMY_DB` apuntando a las bases de datos en formato `.qza` para
 habilitar esta etapa.
 

--- a/scripts/collapse_reads_by_species.py
+++ b/scripts/collapse_reads_by_species.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Collapse read counts per species for each sample.
+
+Reads the ``taxonomy_with_sample.tsv`` table produced by
+``add_reads_and_sample.py`` and outputs, for cada muestra, una tabla con las
+columnas ``Species``, ``Reads`` y ``Proportion`` (0-100). Las especies se
+ordenan por número de lecturas de forma descendente.
+
+Usage:
+    python scripts/collapse_reads_by_species.py <taxonomy_with_sample.tsv>
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(
+            "Usage: collapse_reads_by_species.py <taxonomy_with_sample.tsv>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    in_path = Path(sys.argv[1])
+    if not in_path.is_file():
+        print(f"File not found: {in_path}", file=sys.stderr)
+        sys.exit(1)
+
+    data: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    with in_path.open() as fin:
+        reader = csv.DictReader(fin, delimiter="\t")
+        for row in reader:
+            sample = row["Sample"]
+            species = row["Taxon"]
+            try:
+                reads = int(row["Reads"])
+            except ValueError:
+                reads = 0
+            data[sample][species] += reads
+
+    for sample in sorted(data):
+        species_counts = data[sample]
+        total_reads = sum(species_counts.values())
+        print(f"Sample: {sample}")
+        print("Species\tReads\tProportion")
+        for species, count in sorted(
+            species_counts.items(), key=lambda kv: kv[1], reverse=True
+        ):
+            proportion = (count / total_reads * 100) if total_reads else 0
+            print(f"{species}\t{count}\t{proportion:.2f}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -337,5 +337,11 @@ else
     echo "Rscript no encontrado; omitiendo la generación del gráfico de taxones. Instale R, por ejemplo: 'sudo apt install r-base'."
 fi
 
+print_section "Lecturas por especie"
+python3 scripts/collapse_reads_by_species.py \
+    "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
+    | tee "$UNIFIED_DIR/MaxAc_5/reads_per_species.tsv"
+echo "La tabla y el resto de resultados se guardaron en $UNIFIED_DIR/MaxAc_5"
+
 echo "Pipeline completado. Resultados en: $WORK_DIR"
 echo "Gráfico de calidad vs longitud: $PLOT_FILE"

--- a/tests/test_collapse_reads_by_species.py
+++ b/tests/test_collapse_reads_by_species.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_collapse_reads(tmp_path):
+    table = (
+        "Feature ID\tTaxon\tConsensus\tReads\tSample\n"
+        "id1\tSpecies A\tC1\t10\tS1\n"
+        "id2\tSpecies B\tC2\t5\tS1\n"
+        "id3\tSpecies A\tC3\t20\tS2\n"
+    )
+    in_file = tmp_path / "taxonomy_with_sample.tsv"
+    in_file.write_text(table)
+
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "collapse_reads_by_species.py"
+    )
+    result = subprocess.run(
+        [sys.executable, str(script), str(in_file)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+
+    assert lines[0] == "Sample: S1"
+    assert lines[1] == "Species\tReads\tProportion"
+    assert lines[2].startswith("Species A\t10\t")
+    assert lines[3].startswith("Species B\t5\t")
+    assert lines[4] == "Sample: S2"
+    assert "100.00" in lines[-1]


### PR DESCRIPTION
## Summary
- display per-sample species read table at end of interactive run and save it
- add `collapse_reads_by_species.py` script with tests
- document new summary output in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0e26d5d608321a8258d409f6eace4