### PR TITLE
Handle missing taxon names in bar plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ Esto creará subdirectorios dentro de `<dir_trabajo>` para cada etapa.
 Las rutas de entrada y salida también pueden configurarse manualmente al invocar cada script por separado.
 ## Requisitos
 
-- SeqKit
-- Cutadapt
-- NanoFilt (debe estar instalado antes de ejecutar `scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`)
-- QIIME2
-- R (opcional, necesario para generar el gráfico de calidad vs longitud; puede instalarse con `sudo apt install r-base`)
-- msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para enviar notificaciones por correo)
+ - SeqKit
+ - Cutadapt
+ - NanoFilt (debe estar instalado antes de ejecutar
+   `scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`)
+ - QIIME2
+ - Python con pandas y matplotlib (opcional, necesario para el gráfico de
+   barras de taxones)
+ - R (opcional, necesario para generar el gráfico de calidad vs longitud;
+   puede instalarse con `sudo apt install r-base`)
+ - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para
+   enviar notificaciones por correo)
 
 ## Ejemplos de ejecución
 

--- a/scripts/plot_taxon_bar.R
+++ b/scripts/plot_taxon_bar.R
@@ -23,7 +23,10 @@ data <- read_tsv(input_file, show_col_types = FALSE)
 
 # Asegurarse de que la columna Reads sea numérica y eliminar filas vacías
 plot_data <- data %>%
-  mutate(Reads = suppressWarnings(as.numeric(Reads))) %>%
+  mutate(
+    Reads = suppressWarnings(as.numeric(Reads)),
+    Taxon = if_else(is.na(Taxon) | Taxon == "", "Unassigned", Taxon)
+  ) %>%
   select(Sample, Taxon, Reads) %>%
   filter(!is.na(Reads) & Reads > 0) %>%
   group_by(Sample, Taxon) %>%

--- a/scripts/plot_taxon_bar.py
+++ b/scripts/plot_taxon_bar.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Generate a stacked bar plot of read proportions per sample.
+
+Usage:
+    python scripts/plot_taxon_bar.py <taxonomy.tsv> <output.png>
+
+The input TSV must contain at least the columns Sample, Taxon and Reads.
+Empty or missing taxon names are replaced with "Unassigned" to ensure each
+sample is represented.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", help="TSV file with Sample, Taxon and Reads")
+    parser.add_argument("output", help="Path for the generated PNG plot")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+
+    data = pd.read_csv(in_path, sep="\t", dtype=str)
+
+    data["Reads"] = pd.to_numeric(data["Reads"], errors="coerce")
+    data["Taxon"] = data["Taxon"].fillna("").replace("", "Unassigned")
+    data = data[~data["Reads"].isna() & (data["Reads"] > 0)]
+
+    if data.empty:
+        raise ValueError("No valid reads found in input file")
+
+    grouped = data.groupby(["Sample", "Taxon"], as_index=False)["Reads"].sum()
+    grouped["Percent"] = grouped.groupby("Sample")["Reads"].transform(
+        lambda x: x / x.sum()
+    )
+
+    pivot = grouped.pivot(index="Sample", columns="Taxon", values="Percent")
+    pivot = pivot.fillna(0)
+
+    ax = pivot.plot(kind="bar", stacked=True, figsize=(8, 5))
+    ax.set_ylabel("Proportion of reads")
+    ax.set_xlabel("Sample")
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=300)
+    print(out_path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -305,20 +305,21 @@ echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
 print_section "Gráfico de taxones"
 TAX_PLOT_FILE="N/A"
-if command -v Rscript >/dev/null 2>&1; then
-    TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R \
+if command -v python >/dev/null 2>&1; then
+    TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
         "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | tee -a "$WORK_DIR/r_plot.log" | tail -n 1) || {
-            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | \
+        tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {
+            echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"
             TAX_PLOT_FILE="N/A"
         }
     if [ -f "$TAX_PLOT_FILE" ] && [ "$TAX_PLOT_FILE" != "N/A" ]; then
-        Rscript -e "archivo <- '$TAX_PLOT_FILE'; if (.Platform\$OS.type=='unix') system2('xdg-open', archivo, wait=TRUE) else if (.Platform\$OS.type=='windows') shell.exec(archivo) else system2('open', archivo, wait=TRUE)"
+        xdg-open "$TAX_PLOT_FILE"
     else
         echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
     fi
 else
-    echo "Rscript no encontrado; omitiendo la generación del gráfico de taxones. Instale R, por ejemplo: 'sudo apt install r-base'."
+    echo "Python no encontrado; omitiendo la generación del gráfico de taxones."
 fi
 
 echo "Pipeline completado. Resultados en: $WORK_DIR"

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -118,11 +118,12 @@ run_step 7 clipon-qiime bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_D
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/MaxAc_5"
 
 TAX_PLOT_FILE="N/A"
-if command -v Rscript >/dev/null 2>&1; then
-    TAX_PLOT_FILE=$(Rscript scripts/plot_taxon_bar.R \
+if command -v python >/dev/null 2>&1; then
+    TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
         "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | tee -a "$WORK_DIR/r_plot.log" | tail -n 1) || {
-            echo "Fallo en Rscript: revisar dependencias" >> "$WORK_DIR/r_plot.log"
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | \
+        tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {
+            echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"
             TAX_PLOT_FILE="N/A"
         }
     read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
@@ -132,7 +133,7 @@ if command -v Rscript >/dev/null 2>&1; then
         echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
     fi
 else
-    echo "Rscript no encontrado; omitiendo la generación del gráfico de taxones. Instale R, por ejemplo: 'sudo apt install r-base'."
+    echo "Python no encontrado; omitiendo la generación del gráfico de taxones."
 fi
 
 echo "Pipeline completado. Resultados en: $WORK_DIR"


### PR DESCRIPTION
## Summary
- Replace R-based taxon bar chart with a Python implementation
- Update pipeline scripts to call the Python plotter and log errors
- Document optional Python plotting dependencies

## Testing
- `pytest`
- `shellcheck scripts/run_clipon_interactive.sh scripts/run_clipon_pipeline.sh` *(fails: command not found)*
- `python scripts/plot_taxon_bar.py /tmp/sample_tax.tsv /tmp/out.png`


------
https://chatgpt.com/codex/tasks/task_b_68a0e0fc04208321bd9ea86e70c819da