### PR TITLE
Use mamba for environment installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Para crear los entornos automáticamente ejecute:
 ./scripts/install_envs.sh
 ```
 
-El script verifica que `conda` esté disponible (instala Miniconda si es necesario) y crea los entornos que falten a partir de los YAML.
+El script verifica que `mamba` esté disponible (instala Miniconda y mamba si es necesario) y crea los entornos que falten a partir de los YAML.
 
 ### Descripción de los entornos
 
@@ -87,7 +87,7 @@ El script verifica que `conda` esté disponible (instala Miniconda si es necesar
 - `clipon-qiime`: clustering y clasificación con QIIME 2 y VSEARCH.
 - `clipon-ngs`: generación de consensos con NGSpeciesID.
 
-También puede crearlos manualmente con `mamba` (o `conda`):
+También puede crearlos manualmente con `mamba`:
 
 ```bash
 mamba env create -f envs/clipon-prep.yml
@@ -98,7 +98,7 @@ mamba env create -f envs/clipon-ngs.yml
 Si alguno de los archivos de `envs/` cambia y el entorno ya existe, reconstrúyalo con:
 
 ```bash
-conda env update -f <archivo>.yml
+mamba env update -f <archivo>.yml
 ```
 
 Después de instalar los entornos, verifique su funcionamiento con:

--- a/scripts/install_envs.sh
+++ b/scripts/install_envs.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Script to install ClipON conda environments
-# Checks for conda availability, installs Miniconda if requested,
+# Script to install ClipON environments using mamba
+# Checks for conda and mamba availability, installs Miniconda and mamba if requested,
 # and creates missing environments from the YAML files in ../envs
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,15 +36,24 @@ if ! command -v conda >/dev/null 2>&1; then
   fi
 fi
 
+# Ensure mamba is available
+if ! command -v mamba >/dev/null 2>&1; then
+  echo "Instalando mamba en el entorno base..."
+  if ! conda install -y mamba -n base -c conda-forge; then
+    echo "No se pudo instalar mamba" >&2
+    exit 1
+  fi
+fi
+
 # Iterate over YAML files and create missing environments
 for yml in "$ENV_DIR"/*.yml; do
   env_name="$(basename "$yml" .yml)"
-  if conda env list | awk '{print $1}' | grep -Fxq "$env_name"; then
+  if mamba env list | awk '{print $1}' | grep -Fxq "$env_name"; then
     echo "El entorno '$env_name' ya existe."
   else
     read -rp "El entorno '$env_name' no existe. ¿Desea crearlo? [y/N] " ans
     if [[ $ans =~ ^[Yy]$ ]]; then
-      conda env create -f "$yml"
+      mamba env create -f "$yml"
     else
       echo "Omitiendo '$env_name'."
     fi


### PR DESCRIPTION
## Summary
- switch install_envs.sh to use mamba for faster environment creation
- ensure README instructions reference mamba for environment management

## Testing
- `shellcheck scripts/install_envs.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0e5dae0e08321bb49e02e24240230