### PR TITLE
Add optional sample code mapping for taxon plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ python scripts/collect_read_stats.py <archivo.fastq>
 ```
 Así evita implementar herramientas duplicadas para esta tarea.
 
+### Gráfico de barras de taxones
+El script `scripts/plot_taxon_bar.py` genera un gráfico de barras apiladas con
+la proporción de lecturas por muestra. Con la opción `--code-samples` puede
+reemplazar los nombres de las muestras por códigos secuenciales (`S1`, `S2`,
+...) y guardar la tabla de equivalencias en `<salida>.sample_map.tsv`.
+
+```bash
+python scripts/plot_taxon_bar.py taxonomy_with_sample.tsv plot.png --code-samples
+```
+
 ## Entornos Conda
 
 El repositorio incluye archivos de entorno en `envs/` y un asistente para instalarlos.

--- a/scripts/plot_taxon_bar.py
+++ b/scripts/plot_taxon_bar.py
@@ -3,10 +3,13 @@
 
 Usage:
     python scripts/plot_taxon_bar.py <taxonomy.tsv> <output.png>
+    python scripts/plot_taxon_bar.py <taxonomy.tsv> <output.png> --code-samples
 
 The input TSV must contain at least the columns Sample, Taxon and Reads.
 Empty or missing taxon names are replaced with "Unassigned" to ensure each
-sample is represented.
+sample is represented. When ``--code-samples`` is provided, samples are
+replaced by sequential codes (S1, S2, ...) and the mapping is written to
+``<output>.sample_map.tsv``.
 """
 
 from __future__ import annotations
@@ -23,6 +26,14 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", help="TSV file with Sample, Taxon and Reads")
     parser.add_argument("output", help="Path for the generated PNG plot")
+    parser.add_argument(
+        "--code-samples",
+        action="store_true",
+        help=(
+            "Replace sample names with codes S1, S2, ... and save mapping to "
+            "<output>.sample_map.tsv"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -40,6 +51,16 @@ def main() -> None:
     if data.empty:
         raise ValueError("No valid reads found in input file")
 
+    if args.code_samples:
+        samples = sorted(data["Sample"].unique())
+        sample_map = {sample: f"S{i+1}" for i, sample in enumerate(samples)}
+        map_df = pd.DataFrame(
+            {"code": list(sample_map.values()), "sample": samples}
+        )
+        map_path = out_path.with_suffix(out_path.suffix + ".sample_map.tsv")
+        map_df.to_csv(map_path, sep="\t", index=False)
+        data["Sample"] = data["Sample"].map(sample_map)
+
     grouped = data.groupby(["Sample", "Taxon"], as_index=False)["Reads"].sum()
     grouped["Percent"] = grouped.groupby("Sample")["Reads"].transform(
         lambda x: x / x.sum()
@@ -50,7 +71,8 @@ def main() -> None:
 
     ax = pivot.plot(kind="bar", stacked=True, figsize=(8, 5))
     ax.set_ylabel("Proportion of reads")
-    ax.set_xlabel("Sample")
+    xlabel = "Sample code" if args.code_samples else "Sample"
+    ax.set_xlabel(xlabel)
     plt.tight_layout()
     plt.savefig(out_path, dpi=300)
     print(out_path.resolve())

--- a/scripts/summarize_read_counts.py
+++ b/scripts/summarize_read_counts.py
@@ -57,8 +57,7 @@ for stage, pattern in patterns.items():
 
         counts[base][stage] += num
 
-print("archivo------
-\traw\tprocessed\tfiltered")
+print("sample\traw\tprocessed\tfiltered")
 for sample in sorted(counts):
     data = counts[sample]
     print(f"{sample}\t{data['raw']}\t{data['processed']}\t{data['filtered']}")

--- a/tests/test_plot_taxon_bar.py
+++ b/tests/test_plot_taxon_bar.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_sample_codes(tmp_path):
+    table = (
+        "Sample\tTaxon\tReads\n" "A\tSp1\t10\n" "B\tSp2\t5\n"
+    )
+    in_file = tmp_path / "taxonomy.tsv"
+    in_file.write_text(table)
+    out_file = tmp_path / "plot.png"
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "plot_taxon_bar.py"
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(in_file),
+            str(out_file),
+            "--code-samples",
+        ],
+        check=True,
+        env=env,
+    )
+
+    map_file = tmp_path / "plot.png.sample_map.tsv"
+    content = map_file.read_text().strip().splitlines()
+    assert content[0] == "code\tsample"
+    assert content[1] == "S1\tA"
+    assert content[2] == "S2\tB"


### PR DESCRIPTION
## Summary
- add `--code-samples` option to replace sample names with codes and write mapping
- fix summarize_read_counts header string
- document bar-plot script and new option

## Testing
- `pytest`
- `shellcheck scripts/plot_taxon_bar.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c7b3f39483219f3f8ae44eebdf75