### PR TITLE
Use taxon codes in plot_taxon_bar and export mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ python scripts/collect_read_stats.py <archivo.fastq>
 ```
 Así evita implementar herramientas duplicadas para esta tarea.
 
+### Gráfico de barras de taxones
+Genere un gráfico apilado de proporciones de lecturas por muestra con:
+
+```bash
+python scripts/plot_taxon_bar.py <taxonomy_with_sample.tsv> <salida.png>
+```
+
+El script reemplaza los nombres de taxón por códigos cortos (T1, T2, …) y
+guarda las equivalencias en `<salida>.taxon_map.tsv` con las columnas `code` y
+`taxon`.
+
 ## Entornos Conda
 
 El repositorio incluye archivos de entorno en `envs/` y un asistente para instalarlos.

--- a/scripts/summarize_read_counts.py
+++ b/scripts/summarize_read_counts.py
@@ -57,8 +57,7 @@ for stage, pattern in patterns.items():
 
         counts[base][stage] += num
 
-print("archivo------
-\traw\tprocessed\tfiltered")
+print("archivo\traw\tprocessed\tfiltered")
 for sample in sorted(counts):
     data = counts[sample]
     print(f"{sample}\t{data['raw']}\t{data['processed']}\t{data['filtered']}")


### PR DESCRIPTION
## Summary
- map unique taxa to short codes and save mapping alongside plot
- replace taxon names with codes in stacked bar plot
- document taxon code mapping in README
- fix summarize_read_counts header output to restore CLI functionality

## Testing
- `pycodestyle scripts/plot_taxon_bar.py scripts/summarize_read_counts.py`
- `shellcheck scripts/plot_taxon_bar.py` *(fails: SC1071 ShellCheck only supports sh/bash/dash/ksh scripts)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1c7a4edcc8321addd768f7107a5a1