### PR TITLE
Handle existing work directories in interactive runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeli
 ./scripts/run_clipon_interactive.sh
 ```
 
-Si se elige reanudar, se solicitará el directorio de trabajo existente y se ejecutará `scripts/check_pipeline_status.sh` para mostrar el estado. A continuación, seleccione el paso desde el cual continuar; la elección se guarda en `resume_config.sh` y exporta la variable `RESUME_STEP` antes de llamar al pipeline.
+Si se elige reanudar, se solicitará el directorio de trabajo existente; podrá sobrescribirlo o copiarlo a un nuevo directorio. Luego se ejecutará `scripts/check_pipeline_status.sh` para mostrar el estado. A continuación, seleccione el paso desde el cual continuar; la elección se guarda en `resume_config.sh` y exporta la variable `RESUME_STEP` antes de llamar al pipeline.
+
+En un procesamiento nuevo, si el directorio de salida ya existe y contiene archivos, se pedirá confirmación antes de sobrescribirlo.
 
 ### Formato del Importing Manifest
 Consulte [docs/manifest_example.md](docs/manifest_example.md) para un ejemplo de `ImportingManifest_Manual.csv`. El archivo debe tener las columnas:


### PR DESCRIPTION
## Summary
- allow copying or overwriting work directory when resuming a run
- confirm before overwriting an existing directory in new runs
- document interactive directory prompts in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1caecf0648321b2e3d86dd12316fb