### PR TITLE
Add taxon code mapping to taxon bar plot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Así evita implementar herramientas duplicadas para esta tarea.
 El script `scripts/plot_taxon_bar.py` genera un gráfico de barras apiladas con
 la proporción de lecturas por muestra. Con la opción `--code-samples` puede
 reemplazar los nombres de las muestras por códigos secuenciales (`S1`, `S2`,
-...) y guardar la tabla de equivalencias en `<salida>.sample_map.tsv`.
+...) y guardar la tabla de equivalencias en `<salida>.sample_map.tsv`. Los
+taxones se codifican siempre como `T1`, `T2`, ... y su correspondencia se
+escribe en `<salida>.taxon_map.tsv`.
 
 ```bash
 python scripts/plot_taxon_bar.py taxonomy_with_sample.tsv plot.png --code-samples


### PR DESCRIPTION
## Summary
- map taxa to codes (T1, T2, …) and write code-to-taxon table
- plot using taxon codes and note mapping in legend
- document taxon code mapping in README

## Testing
- `shellcheck scripts/plot_taxon_bar.py` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1ce1c32288321ab044cde7e274a28