### PR TITLE
Use chafa for terminal PNG preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ Las rutas de entrada y salida también pueden configurarse manualmente al invoca
  - NanoFilt (debe estar instalado antes de ejecutar
    `scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh`)
  - QIIME2
- - Python con pandas y matplotlib (opcional, necesario para el gráfico de
+- Python con pandas y matplotlib (opcional, necesario para el gráfico de
    barras de taxones)
- - R (opcional, necesario para generar el gráfico de calidad vs longitud;
+- R (opcional, necesario para generar el gráfico de calidad vs longitud;
    puede instalarse con `sudo apt install r-base`)
- - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para
+- chafa (opcional, para visualizar gráficos PNG en la terminal durante la
+  ejecución interactiva)
+- msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para
    enviar notificaciones por correo)
 
 ## Ejemplos de ejecución
@@ -169,6 +171,7 @@ directorio.  Activará los entornos Conda necesarios automáticamente.
 
 ### Asistente interactivo con reanudación
 El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeline y permite reanudar un procesamiento previo.
+Para visualizar los gráficos generados directamente en la terminal, instale la utilidad `chafa`.
 
 ```bash
 ./scripts/run_clipon_interactive.sh

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -282,7 +282,12 @@ if command -v Rscript >/dev/null 2>&1; then
         }
     echo "Gráfico de calidad vs longitud: $PLOT_FILE"
     if [ -f "$PLOT_FILE" ] && [ "$PLOT_FILE" != "N/A" ]; then
-        Rscript -e "archivo <- '$PLOT_FILE'; if (.Platform\$OS.type=='unix') system2('xdg-open', archivo, wait=TRUE) else if (.Platform\$OS.type=='windows') shell.exec(archivo) else system2('open', archivo, wait=TRUE)"
+        if command -v chafa >/dev/null 2>&1; then
+            # Mostrar el gráfico en la terminal usando chafa
+            chafa "$PLOT_FILE" | less -R
+        else
+            echo "Instale 'chafa' para visualizar el gráfico en la terminal. Archivo: $PLOT_FILE"
+        fi
     else
         echo "No se pudo abrir el gráfico automáticamente."
     fi
@@ -330,7 +335,12 @@ if command -v python >/dev/null 2>&1; then
             TAX_PLOT_FILE="N/A"
         }
     if [ -f "$TAX_PLOT_FILE" ] && [ "$TAX_PLOT_FILE" != "N/A" ]; then
-        xdg-open "$TAX_PLOT_FILE"
+        if command -v chafa >/dev/null 2>&1; then
+            # Visualizar el gráfico de taxones en la terminal
+            chafa "$TAX_PLOT_FILE" | less -R
+        else
+            echo "Instale 'chafa' para visualizar el gráfico en la terminal. Archivo: $TAX_PLOT_FILE"
+        fi
     else
         echo "Gráfico de taxones disponible en: $TAX_PLOT_FILE"
     fi


### PR DESCRIPTION
## Summary
- Use `chafa` to display generated PNG plots directly in the terminal during interactive runs
- Document `chafa` as optional dependency for interactive previews

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a1c617595c83219ff035617fc3fe2e