### PR TITLE
Include chafa in conda environments

### DIFF
--- a/envs/clipon-ngs.yml
+++ b/envs/clipon-ngs.yml
@@ -14,6 +14,7 @@ dependencies:
   - pyspoa=0.2.1
   - pysam=0.23.3
   - pytorch=2.3.1
+  - chafa
   - r-base
   - r-dplyr
   - r-ggplot2

--- a/envs/clipon-prep.yml
+++ b/envs/clipon-prep.yml
@@ -10,6 +10,7 @@ dependencies:
   - pigz=2.8
   - pandas=2.2.2
   - matplotlib=3.8.4
+  - chafa
   - r-base
   - r-ggplot2
   - r-readr

--- a/testenvironment.yml
+++ b/testenvironment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pigz=2.8
   - pandas=2.2.2
   - matplotlib=3.8.4
+  - chafa
   - r-base
   - r-ggplot2
   - r-readr


### PR DESCRIPTION
## Summary
- add chafa dependency to `clipon-prep` and `clipon-ngs` environments
- include chafa in the test environment for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1d2859038832188281653ff166e2b