### PR TITLE
Add eog to Conda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Las rutas de entrada y salida también pueden configurarse manualmente al invoca
    puede instalarse con `sudo apt install r-base`)
 - chafa (opcional, para visualizar gráficos PNG en la terminal durante la
   ejecución interactiva)
+- eog (opcional, para abrir gráficos PNG en un entorno gráfico)
 - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para
-   enviar notificaciones por correo)
+  enviar notificaciones por correo)
 
 ## Ejemplos de ejecución
 
@@ -174,6 +175,7 @@ directorio.  Activará los entornos Conda necesarios automáticamente.
 ### Asistente interactivo con reanudación
 El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeline y permite reanudar un procesamiento previo.
 Para visualizar los gráficos generados directamente en la terminal, instale la utilidad `chafa`.
+También se incluye `eog` para abrir las imágenes en un entorno gráfico.
 
 ```bash
 ./scripts/run_clipon_interactive.sh

--- a/envs/clipon-ngs.yml
+++ b/envs/clipon-ngs.yml
@@ -15,6 +15,7 @@ dependencies:
   - pysam=0.23.3
   - pytorch=2.3.1
   - chafa
+  - eog
   - r-base
   - r-dplyr
   - r-ggplot2

--- a/envs/clipon-prep.yml
+++ b/envs/clipon-prep.yml
@@ -11,6 +11,7 @@ dependencies:
   - pandas=2.2.2
   - matplotlib=3.8.4
   - chafa
+  - eog
   - r-base
   - r-ggplot2
   - r-readr

--- a/envs/clipon-qiime.yml
+++ b/envs/clipon-qiime.yml
@@ -91,6 +91,7 @@ dependencies:
 - cairo=1.18.0
 - certifi=2025.7.14
 - chafa
+- eog
 - cffi=1.17.1
 - chardet=5.2.0
 - charset-normalizer=3.4.2


### PR DESCRIPTION
## Summary
- add `eog` to prep, NGS, and QIIME environment definitions
- document `eog` as optional dependency for viewing generated images

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a1db4e7b448321b141a776ed6ab0cc