### PR TITLE
Use M-prefixed sample codes in taxon bar plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Así evita implementar herramientas duplicadas para esta tarea.
 ### Gráfico de barras de taxones
 El script `scripts/plot_taxon_bar.py` genera un gráfico de barras apiladas con
 la proporción de lecturas por muestra. Con la opción `--code-samples` puede
-reemplazar los nombres de las muestras por códigos secuenciales (`S1`, `S2`,
+reemplazar los nombres de las muestras por códigos secuenciales (`M1`, `M2`,
 ...) y guardar la tabla de equivalencias en `<salida>.sample_map.tsv`. Los
 taxones se codifican siempre como `T1`, `T2`, ... y su correspondencia se
 escribe en `<salida>.taxon_map.tsv`.

--- a/scripts/plot_taxon_bar.py
+++ b/scripts/plot_taxon_bar.py
@@ -8,7 +8,7 @@ Usage:
 The input TSV must contain at least the columns Sample, Taxon and Reads.
 Empty or missing taxon names are replaced with "Unassigned" to ensure each
 sample is represented. When ``--code-samples`` is provided, samples are
-replaced by sequential codes (S1, S2, ...) and the mapping is written to
+replaced by sequential codes (M1, M2, ...) and the mapping is written to
 ``<output>.sample_map.tsv``. Taxa are always replaced by codes (T1, T2, ...)
 and their mapping is saved to ``<output>.taxon_map.tsv``.
 """
@@ -31,7 +31,7 @@ def parse_args() -> argparse.Namespace:
         "--code-samples",
         action="store_true",
         help=(
-            "Replace sample names with codes S1, S2, ... and save mapping to "
+            "Replace sample names with codes M1, M2, ... and save mapping to "
             "<output>.sample_map.tsv"
         ),
     )
@@ -54,7 +54,7 @@ def main() -> None:
 
     if args.code_samples:
         samples = sorted(data["Sample"].unique())
-        sample_map = {sample: f"S{i+1}" for i, sample in enumerate(samples)}
+        sample_map = {sample: f"M{i+1}" for i, sample in enumerate(samples)}
         map_df = pd.DataFrame(
             {"code": list(sample_map.values()), "sample": samples}
         )

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -402,7 +402,8 @@ TAX_PLOT_FILE="N/A"
 if command -v python >/dev/null 2>&1; then
     TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
         "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | \
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" \
+        --code-samples 2>&1 | \
         tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {
             echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"
             TAX_PLOT_FILE="N/A"

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -121,7 +121,8 @@ TAX_PLOT_FILE="N/A"
 if command -v python >/dev/null 2>&1; then
     TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
         "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" 2>&1 | \
+        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" \
+        --code-samples 2>&1 | \
         tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {
             echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"
             TAX_PLOT_FILE="N/A"

--- a/tests/test_plot_taxon_bar.py
+++ b/tests/test_plot_taxon_bar.py
@@ -30,5 +30,5 @@ def test_sample_codes(tmp_path):
     map_file = tmp_path / "plot.png.sample_map.tsv"
     content = map_file.read_text().strip().splitlines()
     assert content[0] == "code\tsample"
-    assert content[1] == "S1\tA"
-    assert content[2] == "S2\tB"
+    assert content[1] == "M1\tA"
+    assert content[2] == "M2\tB"


### PR DESCRIPTION
## Summary
- Encode samples as M1, M2… when using plot_taxon_bar.py
- Generate taxon bar plot with coded samples in run scripts
- Document new sample code prefix in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh scripts/run_clipon_pipeline.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1e27791e8832189cb8be8f1a7619e