### PR TITLE
Use Results directory for unified outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 4. **Clustering** – `NGSpeciesID` agrupa secuencias y genera consensos.
 5. **Unificación de clusters** – se combinan los consensos de distintos experimentos.
 6. **Clasificación opcional** – el script `scripts/De3_A4_Classify_NGS.sh` usa `qiime feature-classifier classify-consensus-blast` para asignar taxonomía a los consensos unificados.
-7. **Exportación de la clasificación** – `scripts/De3_A4_Export_Classification.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `MaxAc_5`. Además, crea `reads_per_species.tsv` con el número total de lecturas por especie y muestra.
+7. **Exportación de la clasificación** – `scripts/De3_A4_Export_Classification.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `Results`. Además, crea `reads_per_species.tsv` con el número total de lecturas por especie y muestra.
 
 
 ## Uso rápido
@@ -21,7 +21,7 @@ Ejecuta todo el flujo con:
 ```
 El directorio `<dir_trabajo>/5_unified` contendrá los archivos de clasificación
 `taxonomy.qza` y `search_results.qza`. El paso de exportación generará copias en
-texto dentro de `5_unified/MaxAc_5`, incluyendo `taxonomy_with_sample.tsv` con
+texto dentro de `5_unified/Results`, incluyendo `taxonomy_with_sample.tsv` con
 las columnas adicionales *Reads* y *Sample* y `reads_per_species.tsv` con los
 conteos de lecturas por especie y muestra. Defina las variables de entorno
 `BLAST_DB` y `TAXONOMY_DB` apuntando a las bases de datos en formato `.qza` para

--- a/scripts/De2_En_Adelante_Procesamiento_NGSpecies.sh
+++ b/scripts/De2_En_Adelante_Procesamiento_NGSpecies.sh
@@ -35,9 +35,9 @@ qiime feature-classifier classify-consensus-blast \
 ### EXPORTADO DE LA TABLA DE TAXONOMIA
 				qiime tools export \
         --input-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/taxonomy.qza" \
-        --output-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/MaxAc_5/"
+        --output-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/Results/"
 
 ### EXPORTADO DE LA TABLA DE TAXONOMIA
 				qiime tools export \
         --input-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/search_results.qza" \
-        --output-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/MaxAc_5/"
+        --output-path "/home/adriano_abb/Qiime/V2/Trim_NGSpecies/Results/"

--- a/scripts/check_pipeline_status.sh
+++ b/scripts/check_pipeline_status.sh
@@ -25,7 +25,7 @@ MARKERS=(
     "$WORK_DIR/4_clustered/*"
     "$WORK_DIR/5_unified/consensos_todos.fasta"
     "$WORK_DIR/5_unified/taxonomy.qza"
-    "$WORK_DIR/5_unified/MaxAc_5"
+    "$WORK_DIR/5_unified/Results"
 )
 
 echo "Comprobando estado del pipeline en $WORK_DIR"

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -406,8 +406,8 @@ print_section "Gráfico de taxones"
 TAX_PLOT_FILE="N/A"
 if command -v python >/dev/null 2>&1; then
     TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
-        "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" \
+        "$UNIFIED_DIR/Results/taxonomy_with_sample.tsv" \
+        "$UNIFIED_DIR/Results/taxon_stacked_bar.png" \
         --code-samples 2>&1 | \
 
         tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -120,8 +120,8 @@ echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/Results"
 TAX_PLOT_FILE="N/A"
 if command -v python >/dev/null 2>&1; then
     TAX_PLOT_FILE=$(python scripts/plot_taxon_bar.py \
-        "$UNIFIED_DIR/MaxAc_5/taxonomy_with_sample.tsv" \
-        "$UNIFIED_DIR/MaxAc_5/taxon_stacked_bar.png" \
+        "$UNIFIED_DIR/Results/taxonomy_with_sample.tsv" \
+        "$UNIFIED_DIR/Results/taxon_stacked_bar.png" \
         --code-samples 2>&1 | \
         tee -a "$WORK_DIR/taxon_plot.log" | tail -n 1) || {
             echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"


### PR DESCRIPTION
## Summary
- replace outdated `MaxAc_5` paths with `Results`
- update README to point to new `5_unified/Results` folder

## Testing
- `shellcheck scripts/check_pipeline_status.sh`
- `shellcheck scripts/run_clipon_pipeline.sh`
- `shellcheck scripts/run_clipon_interactive.sh`
- `shellcheck scripts/De2_En_Adelante_Procesamiento_NGSpecies.sh` *(errors: SC2148, SC1017, SC2215)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68a1e6769b5c8321972bd5322fb23ec8