### PR TITLE
Load resume step from config in interactive runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ También se incluye `eog` para abrir las imágenes en un entorno gráfico.
 ./scripts/run_clipon_interactive.sh
 ```
 
-Si se elige reanudar, se solicitará el directorio de trabajo existente; podrá sobrescribirlo o copiarlo a un nuevo directorio. Luego se ejecutará `scripts/check_pipeline_status.sh` para mostrar el estado. A continuación, seleccione el paso desde el cual continuar; la elección se guarda en `resume_config.sh` y exporta la variable `RESUME_STEP` antes de llamar al pipeline.
+Si se elige reanudar, se solicitará el directorio de trabajo existente; podrá sobrescribirlo o copiarlo a un nuevo directorio. Luego se ejecutará `scripts/check_pipeline_status.sh` para mostrar el estado y solicitar el paso desde el cual continuar. El valor elegido se guarda en `resume_config.sh` y se carga automáticamente para definir la variable `RESUME_STEP` antes de llamar al pipeline.
 
 Tras el resumen de configuración, el asistente permite ingresar una línea con parámetros adicionales que se añadirán a los comandos de los scripts internos. Esta opción ofrece flexibilidad para ajustar hilos, filtros u otros valores sin modificar directamente los scripts.
 

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -79,8 +79,7 @@ if [ "$MODE" = "resume" ]; then
         fi
     done
     scripts/check_pipeline_status.sh "$WORK_DIR"
-    read -rp "Seleccione el paso de reanudación: " RESUME_STEP
-    echo "export RESUME_STEP=\"$RESUME_STEP\"" > "$WORK_DIR/resume_config.sh"
+    # Leer RESUME_STEP desde el archivo generado por check_pipeline_status.sh
     source "$WORK_DIR/resume_config.sh"
 fi
 


### PR DESCRIPTION
## Summary
- Source resume configuration after checking pipeline status
- Clarify resume behaviour in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest`
- `PATH="/tmp:$PATH" scripts/run_clipon_interactive.sh` (resume flow)


------
https://chatgpt.com/codex/tasks/task_b_68a1e68dd2cc83218ac164fe77b640e9