### PR TITLE
Remove GUI tools from conda envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ Las rutas de entrada y salida también pueden configurarse manualmente al invoca
    barras de taxones)
 - R (opcional, necesario para generar el gráfico de calidad vs longitud;
    puede instalarse con `sudo apt install r-base`)
-- chafa (opcional, para visualizar gráficos PNG en la terminal durante la
-  ejecución interactiva)
-- eog (opcional, para abrir gráficos PNG en un entorno gráfico)
+- eog (opcional, instale con `apt install eog` para abrir gráficos PNG en un
+  entorno gráfico)
 - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para
   enviar notificaciones por correo)
 
@@ -186,7 +185,7 @@ directorio.  Activará los entornos Conda necesarios automáticamente.
 
 ### Asistente interactivo con reanudación
 El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeline y permite reanudar un procesamiento previo.
-También se incluye `eog` para abrir las imágenes en un entorno gráfico.
+Intentará abrir las imágenes con `eog` si está instalado en el sistema.
 
 ```bash
 ./scripts/run_clipon_interactive.sh

--- a/envs/clipon-ngs.yml
+++ b/envs/clipon-ngs.yml
@@ -14,8 +14,6 @@ dependencies:
   - pyspoa=0.2.1
   - pysam=0.23.3
   - pytorch=2.3.1
-  - chafa
-  - eog
   - r-base
   - r-dplyr
   - r-ggplot2

--- a/envs/clipon-prep.yml
+++ b/envs/clipon-prep.yml
@@ -10,8 +10,6 @@ dependencies:
   - pigz=2.8
   - pandas=2.2.2
   - matplotlib=3.8.4
-  - chafa
-  - eog
   - r-base
   - r-ggplot2
   - r-readr

--- a/envs/clipon-qiime.yml
+++ b/envs/clipon-qiime.yml
@@ -90,8 +90,6 @@ dependencies:
 - cached_property=1.5.2
 - cairo=1.18.0
 - certifi=2025.7.14
-- chafa
-- eog
 - cffi=1.17.1
 - chardet=5.2.0
 - charset-normalizer=3.4.2

--- a/testenvironment.yml
+++ b/testenvironment.yml
@@ -26,7 +26,6 @@ dependencies:
   - pigz=2.8
   - pandas=2.2.2
   - matplotlib=3.8.4
-  - chafa
   - r-base
   - r-ggplot2
   - r-readr


### PR DESCRIPTION
## Summary
- drop `chafa` and `eog` from all conda environment files
- document that `eog` should be installed via the system package manager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68a1f658a0c48321908cb3e85b66490a