### PR TITLE
Enhance sample name handling in taxonomy utilities

### DIFF
--- a/tests/test_add_reads_and_sample.py
+++ b/tests/test_add_reads_and_sample.py
@@ -1,0 +1,44 @@
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_script(input_text: str, tmp_path: Path, metadata: Path | None = None) -> Path:
+    in_file = tmp_path / "taxonomy.tsv"
+    in_file.write_text(input_text)
+    script = Path(__file__).resolve().parents[1] / "scripts" / "add_reads_and_sample.py"
+    cmd = [sys.executable, str(script), str(in_file)]
+    if metadata is not None:
+        cmd.extend(["--metadata", str(metadata)])
+    subprocess.run(cmd, check=True)
+    return in_file.with_name("taxonomy_with_sample.tsv")
+
+
+def read_samples(path: Path) -> list[str]:
+    with path.open() as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        return [row["Sample"] for row in reader]
+
+
+def test_clean_prefix_suffix(tmp_path):
+    table = (
+        "Feature ID\tTaxon\tConsensus\n"
+        "foo_total_supporting_reads_10_cleaned_S1_trimmed\tSp1\t1\n"
+    )
+    out_file = run_script(table, tmp_path)
+    samples = read_samples(out_file)
+    assert samples == ["S1"]
+
+
+def test_metadata_replacement(tmp_path):
+    table = (
+        "Feature ID\tTaxon\tConsensus\n"
+        "foo_total_supporting_reads_10_cleaned_S1_trimmed\tSp1\t1\n"
+    )
+    meta = tmp_path / "meta.tsv"
+    meta.write_text("fastq\texperiment\nS1\tExp1\n")
+    out_file = run_script(table, tmp_path, metadata=meta)
+    samples = read_samples(out_file)
+    assert samples == ["Exp1"]
+

--- a/tests/test_plot_taxon_bar.py
+++ b/tests/test_plot_taxon_bar.py
@@ -63,3 +63,60 @@ def test_metadata_mapping(tmp_path):
     map_file = tmp_path / "plot.png.sample_map.tsv"
     content = map_file.read_text().strip().splitlines()
     assert content[1] == "M1\tExp1"
+
+
+def test_metadata_partial_match_with_processed_names(tmp_path):
+    table = "Sample\tTaxon\tReads\ncleaned_A_trimmed\tSp1\t10\n"
+    in_file = tmp_path / "taxonomy.tsv"
+    in_file.write_text(table)
+    out_file = tmp_path / "plot.png"
+
+    meta = tmp_path / "meta.tsv"
+    meta.write_text("fastq\texperiment\nA\tExp1\n")
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "plot_taxon_bar.py"
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(in_file),
+            str(out_file),
+            "--metadata",
+            str(meta),
+            "--code-samples",
+        ],
+        check=True,
+        env=env,
+    )
+
+    map_file = tmp_path / "plot.png.sample_map.tsv"
+    content = map_file.read_text().strip().splitlines()
+    assert content[1] == "M1\tExp1"
+
+
+def test_fallback_to_clean_fastq(tmp_path):
+    table = "Sample\tTaxon\tReads\ncleaned_B_trimmed\tSp1\t10\n"
+    in_file = tmp_path / "taxonomy.tsv"
+    in_file.write_text(table)
+    out_file = tmp_path / "plot.png"
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "plot_taxon_bar.py"
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(in_file),
+            str(out_file),
+            "--code-samples",
+        ],
+        check=True,
+        env=env,
+    )
+
+    map_file = tmp_path / "plot.png.sample_map.tsv"
+    content = map_file.read_text().strip().splitlines()
+    assert content[1] == "M1\tB"


### PR DESCRIPTION
## Summary
- normalize FASTQ-derived sample names in `add_reads_and_sample.py` and replace them with experiment IDs when metadata is provided
- support partial metadata matches and FASTQ name cleanup in `plot_taxon_bar.py`
- add tests for sample name normalization and metadata-based renaming

## Testing
- `shellcheck scripts/add_reads_and_sample.py scripts/plot_taxon_bar.py` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1fcb9fa048321bae5ab843b46da19