### PR TITLE
Prompt for metadata file when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ directorio.  Activará los entornos Conda necesarios automáticamente.
 
 ### Asistente interactivo con reanudación
 El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeline y permite reanudar un procesamiento previo.
+Puede recibir `--metadata <archivo>`; si no se proporciona, pedirá la ruta durante la ejecución.
 Intentará abrir las imágenes con `eog` si está instalado en el sistema.
 
 ```bash

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -15,6 +15,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Solicitar archivo de metadata si no se proporcionó por argumento
+if [ -z "$METADATA_FILE" ]; then
+    while true; do
+        read -rp "Ingrese la ruta del archivo de metadata (Enter para omitir): " METADATA_FILE
+        if [ -z "$METADATA_FILE" ]; then
+            break
+        elif [ -f "$METADATA_FILE" ]; then
+            break
+        else
+            echo "El archivo '$METADATA_FILE' no existe. Intente nuevamente."
+        fi
+    done
+fi
+
 # Función auxiliar para solicitar parámetros con un valor por defecto
 prompt_param() {
     local var_name="$1"


### PR DESCRIPTION
## Summary
- Ask for metadata file interactively when `--metadata` argument is omitted
- Document interactive metadata prompt in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1fda8184c8321814cd6ee7bd49e11