### PR TITLE
Install eog during environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ habilitar esta etapa.
 
 Esto creará subdirectorios dentro de `<dir_trabajo>` para cada etapa.
 Las rutas de entrada y salida también pueden configurarse manualmente al invocar cada script por separado.
+
+## Configuración
+
+Ejecuta `./setup.sh` para instalar Miniconda, crear los entornos necesarios y asegurar la presencia de `eog` para la visualización de imágenes.
 ## Requisitos
 
  - SeqKit

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Instala eog para la visualización de imágenes
+if ! command -v eog >/dev/null 2>&1; then
+  echo "Instalando eog..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -y
+    sudo apt-get install -y eog
+  else
+    echo "apt-get no está disponible; instala eog manualmente." >&2
+  fi
+fi
+
 # Instala/actualiza Miniconda y crea los entornos requeridos
 ./scripts/install_envs.sh
 


### PR DESCRIPTION
## Summary
- install Eye of GNOME (eog) when running setup script
- document new setup step in README

## Testing
- `shellcheck setup.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1ffc4f8b883219efe9b15a99da8f9