### PR TITLE
Clarify raw dataset labeling and color scale in quality plot

### DIFF
--- a/scripts/plot_quality_vs_length.R
+++ b/scripts/plot_quality_vs_length.R
@@ -17,7 +17,7 @@ suppressPackageStartupMessages({
 })
 
 cleaned <- readr::read_tsv(file_cleaned, show_col_types = FALSE)
-cleaned$dataset <- "cleaned"
+cleaned$dataset <- "raw"
 
 filtered <- readr::read_tsv(file_filtered, show_col_types = FALSE)
 filtered$dataset <- "filtered"
@@ -27,6 +27,7 @@ df <- rbind(cleaned, filtered)
 p <- ggplot(df, aes(x = length, y = mean_quality, color = dataset)) +
   geom_point(alpha = 0.4) +
   labs(x = "Read length", y = "Mean quality score", color = "Dataset") +
+  scale_color_manual(values = c(raw = "#1f77b4", filtered = "#ff7f0e")) +
   theme_minimal()
 
 ggsave(output_png, plot = p, width = 6, height = 4, units = "in")


### PR DESCRIPTION
## Summary
- Label the "cleaned" dataset as "raw" in quality vs. length plot generation.
- Add a manual color scale for clearer differentiation between raw and filtered datasets.

## Testing
- `shellcheck scripts/plot_quality_vs_length.R` *(fails: command not found)*
- `pytest`
- `Rscript scripts/plot_quality_vs_length.R /tmp/plot_test`

------
https://chatgpt.com/codex/tasks/task_b_68a2026eb5688321855d2ce1c41f2191