### PR TITLE
Prompt for metadata after FASTQ selection in interactive run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ directorio.  Activará los entornos Conda necesarios automáticamente.
 
 ### Asistente interactivo con reanudación
 El script `scripts/run_clipon_interactive.sh` guía la configuración del pipeline y permite reanudar un procesamiento previo.
-Puede recibir `--metadata <archivo>`; si no se proporciona, pedirá la ruta durante la ejecución.
+Puede recibir `--metadata <archivo>`; si no se proporciona, pedirá la ruta durante la ejecución
+después de indicar los archivos FASTQ.
 Intentará abrir las imágenes con `eog` si está instalado en el sistema.
 
 ```bash

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -15,20 +15,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Solicitar archivo de metadata si no se proporcionó por argumento
-if [ -z "$METADATA_FILE" ]; then
-    while true; do
-        read -rp "Ingrese la ruta del archivo de metadata (Enter para omitir): " METADATA_FILE
-        if [ -z "$METADATA_FILE" ]; then
-            break
-        elif [ -f "$METADATA_FILE" ]; then
-            break
-        else
-            echo "El archivo '$METADATA_FILE' no existe. Intente nuevamente."
-        fi
-    done
-fi
-
 # Función auxiliar para solicitar parámetros con un valor por defecto
 prompt_param() {
     local var_name="$1"
@@ -130,6 +116,21 @@ if [ "$MODE" = "new" ] || [ "${RESUME_STEP:-1}" -le 1 ]; then
             continue
         fi
         break
+    done
+fi
+
+# Solicitar archivo de metadata después de los FASTQ si no se proporcionó
+# por argumento
+if [ -z "$METADATA_FILE" ]; then
+    while true; do
+        read -rp "Ingrese la ruta del archivo de metadata (Enter para omitir): " METADATA_FILE
+        if [ -z "$METADATA_FILE" ]; then
+            break
+        elif [ -f "$METADATA_FILE" ]; then
+            break
+        else
+            echo "El archivo '$METADATA_FILE' no existe. Intente nuevamente."
+        fi
     done
 fi
 


### PR DESCRIPTION
## Summary
- Ask for metadata file after prompting for FASTQ directory
- Document updated metadata prompt order in README

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a200065e448321bbfc5e9a931d658b