### PR TITLE
Unify dataset colors in quality plot

### DIFF
--- a/scripts/plot_quality_vs_length.R
+++ b/scripts/plot_quality_vs_length.R
@@ -17,16 +17,24 @@ suppressPackageStartupMessages({
 })
 
 cleaned <- readr::read_tsv(file_cleaned, show_col_types = FALSE)
-cleaned$dataset <- "cleaned"
-
 filtered <- readr::read_tsv(file_filtered, show_col_types = FALSE)
-filtered$dataset <- "filtered"
 
-df <- rbind(cleaned, filtered)
-
-p <- ggplot(df, aes(x = length, y = mean_quality, color = dataset)) +
-  geom_point(alpha = 0.4) +
-  labs(x = "Read length", y = "Mean quality score", color = "Dataset") +
+p <- ggplot() +
+  geom_point(
+    data = cleaned,
+    aes(x = length, y = mean_quality, color = "raw"),
+    alpha = 0.4
+  ) +
+  geom_point(
+    data = filtered,
+    aes(x = length, y = mean_quality, color = "filtered"),
+    alpha = 0.4
+  ) +
+  labs(x = "Read length", y = "Mean quality score") +
+  scale_color_manual(
+    values = c(raw = "#1f77b4", filtered = "#ff7f0e"),
+    name = "Dataset"
+  ) +
   theme_minimal()
 
 ggsave(output_png, plot = p, width = 6, height = 4, units = "in")


### PR DESCRIPTION
## Summary
- Plot raw and filtered reads with distinct single colors in quality vs. length visualization
- Retain manual color scale and legend for clearer dataset differentiation

## Testing
- `shellcheck scripts/plot_quality_vs_length.R` *(fails: command not found)*
- `pytest`
- `Rscript scripts/plot_quality_vs_length.R /tmp/plot_test` *(fails: package 'ggplot2' not available)*

------
https://chatgpt.com/codex/tasks/task_b_68a2026eb5688321855d2ce1c41f2191