### PR TITLE
Format taxon names when collapsing reads

### DIFF
--- a/tests/test_collapse_reads_by_species.py
+++ b/tests/test_collapse_reads_by_species.py
@@ -6,9 +6,9 @@ from pathlib import Path
 def test_collapse_reads(tmp_path):
     table = (
         "Feature ID\tTaxon\tConsensus\tReads\tSample\n"
-        "id1\tSpecies A\tC1\t10\tS1\n"
-        "id2\tSpecies B\tC2\t5\tS1\n"
-        "id3\tSpecies A\tC3\t20\tS2\n"
+        "id1\tk__Bacteria; g__Escherichia; s__coli\tC1\t10\tS1\n"
+        "id2\tk__Bacteria; g__Bacillus\tC2\t5\tS1\n"
+        "id3\tk__Bacteria f__Bacillaceae\tC3\t20\tS2\n"
     )
     in_file = tmp_path / "taxonomy_with_sample.tsv"
     in_file.write_text(table)
@@ -29,7 +29,9 @@ def test_collapse_reads(tmp_path):
 
     assert lines[0] == "Sample: S1"
     assert lines[1] == "Species\tReads\tProportion"
-    assert lines[2].startswith("Species A\t10\t")
-    assert lines[3].startswith("Species B\t5\t")
+    assert lines[2].startswith("*Escherichia coli*\t10\t")
+    assert lines[3].startswith("*Bacillus* (genus)\t5\t")
     assert lines[4] == "Sample: S2"
-    assert "100.00" in lines[-1]
+    assert lines[5] == "Species\tReads\tProportion"
+    assert lines[6].startswith("Bacillaceae (family)\t20\t")
+    assert lines[6].endswith("100.00")


### PR DESCRIPTION
## Summary
- add `format_taxon` helper to format genus/species names
- apply formatting in `collapse_reads_by_species.py`
- update unit test for new formatted output

## Testing
- `pytest tests/test_collapse_reads_by_species.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a23872170483218c9f8606ebcf2af3