### PR TITLE
Add missing sys import in summarize_read_counts

### DIFF
--- a/scripts/summarize_read_counts.py
+++ b/scripts/summarize_read_counts.py
@@ -17,6 +17,7 @@ import glob
 import os
 import pathlib
 import re
+import sys
 from collections import defaultdict
 
 


### PR DESCRIPTION
## Summary
- add missing `sys` import to scripts/summarize_read_counts.py to avoid NameError

## Testing
- `pytest tests/test_summarize_read_counts.py`
- `shellcheck scripts/summarize_read_counts.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a239b4f2648321a0edf50817b0ae11