### PR TITLE
Add VSEARCH clustering option to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 1. **Procesamiento inicial** – se filtran secuencias corruptas con `SeqKit`.
 2. **Recorte de cebadores** – `Cutadapt` elimina bases al inicio y fin.
 3. **Filtrado de calidad y longitud** – `NanoFilt` descarta lecturas cortas o de baja calidad.
-4. **Clustering** – `NGSpeciesID` agrupa secuencias y genera consensos.
+4. **Clustering** – por defecto, `NGSpeciesID` agrupa secuencias y genera consensos; alternativamente, use `--cluster-method vsearch` para ejecutar `VSEARCH`.
 5. **Unificación de clusters** – se combinan los consensos de distintos experimentos.
 6. **Clasificación opcional** – el script `scripts/De3_A4_Classify_NGS.sh` usa `qiime feature-classifier classify-consensus-blast` para asignar taxonomía a los consensos unificados.
 7. **Exportación de la clasificación** – `scripts/De3_A4_Export_Classification.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `Results`. Además, crea `reads_per_species.tsv` con el número total de lecturas por especie y muestra.
@@ -17,7 +17,7 @@
 Ejecuta todo el flujo con:
 
 ```bash
-./scripts/run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
+./scripts/run_clipon_pipeline.sh [--cluster-method <ngspecies|vsearch>] <dir_fastq_entrada> <dir_trabajo>
 ```
 
 Para reemplazar los nombres de los archivos FASTQ por identificadores de
@@ -25,7 +25,7 @@ experimento, proporcione un archivo de metadata con columnas `fastq` y
 `experiment`:
 
 ```bash
-./scripts/run_clipon_pipeline.sh --metadata fastq_metadata.tsv <dir_fastq_entrada> <dir_trabajo>
+./scripts/run_clipon_pipeline.sh --metadata fastq_metadata.tsv [--cluster-method <ngspecies|vsearch>] <dir_fastq_entrada> <dir_trabajo>
 ```
 Consulte [docs/metadata_example.md](docs/metadata_example.md) para un ejemplo de
 formato.
@@ -185,7 +185,7 @@ El wrapper `run_clipon_pipeline.sh` puede ejecutarse desde cualquier
 directorio.  Activará los entornos Conda necesarios automáticamente.
 
 ```bash
-./scripts/run_clipon_pipeline.sh <dir_fastq_entrada> <dir_trabajo>
+./scripts/run_clipon_pipeline.sh [--cluster-method <ngspecies|vsearch>] <dir_fastq_entrada> <dir_trabajo>
 ```
 
 ### Asistente interactivo con reanudación

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Wrapper para ejecutar la cadena completa de procesamiento de ClipON
-# Uso: ./run_clipon_pipeline.sh [--metadata <archivo>] <dir_fastq_entrada> <dir_trabajo>
+# Uso: ./run_clipon_pipeline.sh [--metadata <archivo>] [--cluster-method <ngspecies|vsearch>] <dir_fastq_entrada> <dir_trabajo>
 # El directorio de trabajo contendrá subcarpetas para cada etapa
 
 # Para un gráfico avanzado de la calidad de lectura combine los TSV generados en cada etapa (collect_read_stats.py):
@@ -17,11 +17,16 @@ cd "$ROOT_DIR"
 # Inicializar conda y activar entornos según la etapa
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
+CLUSTER_METHOD="${CLUSTER_METHOD:-ngspecies}"
 METADATA_FILE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --metadata)
             METADATA_FILE="${2:-}"
+            shift 2
+            ;;
+        --cluster-method)
+            CLUSTER_METHOD="${2:-ngspecies}"
             shift 2
             ;;
         *)
@@ -31,7 +36,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$#" -ne 2 ]; then
-    echo "Uso: $0 [--metadata <archivo>] <dir_fastq_entrada> <dir_trabajo>"
+    echo "Uso: $0 [--metadata <archivo>] [--cluster-method <ngspecies|vsearch>] <dir_fastq_entrada> <dir_trabajo>"
     exit 1
 fi
 
@@ -93,6 +98,13 @@ classify_reads() {
     echo "Clasificación finalizada. Revise $UNIFIED_DIR/Results"
 }
 
+cluster_with_vsearch() {
+    scripts/generate_manifest.sh --filtered "$FILTER_DIR" > "$FILTER_DIR/manifest.csv"
+    scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh "$FILTER_DIR/manifest.csv" "$VSEARCH_PREFIX" "$DIRDB" "$EMAIL" "$CLUSTER_ID" "$BLAST_ID" "$MAX_ACCEPTS"
+    cp "$VSEARCH_PREFIX"/taxonomy.qza "$UNIFIED_DIR/taxonomy.qza"
+    cp "$VSEARCH_PREFIX"/search_results.qza "$UNIFIED_DIR/search_results.qza"
+}
+
 run_step 1 clipon-prep INPUT_DIR="$INPUT_DIR" OUTPUT_DIR="$PROCESSED_DIR" bash scripts/De0_A1_Process_Fastq.4_SeqKit.sh
 run_step 2 clipon-prep trim_reads
 run_step 3 clipon-prep INPUT_DIR="$TRIM_DIR" OUTPUT_DIR="$FILTER_DIR" LOG_FILE="$LOG_FILE" bash scripts/De1.5_A2_Filtrado_NanoFilt_1.1.sh
@@ -117,16 +129,30 @@ else
 fi
 
 echo "Gráfico de calidad vs longitud: $PLOT_FILE"
+echo "Usando método de clustering: $CLUSTER_METHOD"
 
-run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/De2_A2.5_NGSpecies_Clustering.sh
-run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
-
-if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
-    echo "No se creó el archivo maestro de consensos. Abortando pipeline."
-    exit 1
-fi
-
-run_step 6 clipon-qiime classify_reads
+case "$CLUSTER_METHOD" in
+    ngspecies)
+        echo "Clustering con NGSpeciesID..."
+        run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/De2_A2.5_NGSpecies_Clustering.sh
+        run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+        if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
+            echo "No se creó el archivo maestro de consensos. Abortando pipeline."
+            exit 1
+        fi
+        run_step 6 clipon-qiime classify_reads
+        ;;
+    vsearch)
+        echo "Clustering con VSEARCH..."
+        run_step 4 clipon-qiime cluster_with_vsearch
+        run_step 5 clipon-qiime true
+        run_step 6 clipon-qiime true
+        ;;
+    *)
+        echo "Método de clustering no válido: $CLUSTER_METHOD" >&2
+        exit 1
+        ;;
+esac
 run_step 7 clipon-qiime METADATA_FILE="$METADATA_FILE" bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/Results"


### PR DESCRIPTION
## Summary
- allow choosing clustering backend via `--cluster-method` (NGSpeciesID or VSEARCH)
- update README usage examples to document new option

## Testing
- `pytest`
- `shellcheck scripts/run_clipon_pipeline.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a241447c108321b90a019411aea7e2