### PR TITLE
Define pipeline stage directories in interactive script

### DIFF
--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -154,6 +154,18 @@ if [ "$MODE" = "new" ]; then
     done
 fi
 
+# Definir y crear subdirectorios de trabajo
+PROCESSED_DIR="$WORK_DIR/1_processed"
+TRIM_DIR="$WORK_DIR/2_trimmed"
+FILTER_DIR="$WORK_DIR/3_filtered"
+CLUSTER_DIR="$WORK_DIR/4_clustered"
+UNIFIED_DIR="$WORK_DIR/5_unified"
+
+mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR"
+
+# Exportar variables de directorio para uso posterior
+export PROCESSED_DIR TRIM_DIR FILTER_DIR CLUSTER_DIR UNIFIED_DIR
+
 # Solicitar rutas para bases de datos necesarias
 while true; do
     read -rp "Ingrese la ruta al archivo de base de datos BLAST (.qza): " BLAST_DB


### PR DESCRIPTION
## Summary
- create and export processing stage directories in `run_clipon_interactive.sh`
- ensure directories exist for subsequent steps

## Testing
- `shellcheck scripts/run_clipon_interactive.sh`
- `pytest` *(fails: R is required for plotting tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a26eaa55908321afe1bae19184685e