### PR TITLE
Compare filtered vs pre-filtered reads in quality-length plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Ejecuta `./setup.sh` para instalar Miniconda, crear los entornos necesarios y as
  - QIIME2
 - Python con pandas y matplotlib (opcional, necesario para el gráfico de
    barras de taxones)
-- R (opcional, necesario para generar el gráfico de calidad vs longitud;
-   puede instalarse con `sudo apt install r-base`)
+- R (opcional, necesario para generar el gráfico de calidad vs longitud que
+  compara lecturas antes y después del filtrado sin distinguir el origen de
+  las muestras; puede instalarse con `sudo apt install r-base`)
 - eog (opcional, instale con `apt install eog` para abrir gráficos PNG en un
   entorno gráfico)
 - msmtp (utilizado por `scripts/De2_A4__VSearch_Procesonuevo2.6.1.sh` para

--- a/scripts/plot_quality_vs_length.R
+++ b/scripts/plot_quality_vs_length.R
@@ -6,7 +6,7 @@ if (length(args) != 1) {
 }
 
 work_dir <- args[1]
-file_cleaned <- file.path(work_dir, "read_stats_cleaned.tsv")
+file_prefilter <- file.path(work_dir, "read_stats_cleaned.tsv")
 file_filtered <- file.path(work_dir, "read_stats_650_750_Q10.tsv")
 output_png <- normalizePath(file.path(work_dir, "read_quality_vs_length.png"),
                              mustWork = FALSE)
@@ -16,13 +16,13 @@ suppressPackageStartupMessages({
   library(readr)
 })
 
-cleaned <- readr::read_tsv(file_cleaned, show_col_types = FALSE)
+prefilter <- readr::read_tsv(file_prefilter, show_col_types = FALSE)
 filtered <- readr::read_tsv(file_filtered, show_col_types = FALSE)
 
 p <- ggplot() +
   geom_point(
-    data = cleaned,
-    aes(x = length, y = mean_quality, color = "raw"),
+    data = prefilter,
+    aes(x = length, y = mean_quality, color = "pre_filter"),
     alpha = 0.4
   ) +
   geom_point(
@@ -32,8 +32,9 @@ p <- ggplot() +
   ) +
   labs(x = "Read length", y = "Mean quality score") +
   scale_color_manual(
-    values = c(raw = "#1f77b4", filtered = "#ff7f0e"),
-    name = "Dataset"
+    values = c(pre_filter = "#1f77b4", filtered = "#ff7f0e"),
+    name = "Dataset",
+    labels = c(pre_filter = "Pre-filter", filtered = "Filtered")
   ) +
 
   theme_minimal()

--- a/scripts/plot_quality_vs_length_multi.R
+++ b/scripts/plot_quality_vs_length_multi.R
@@ -1,25 +1,16 @@
 #!/usr/bin/env Rscript
 
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) < 3) {
-  stop(
-    "Usage: plot_quality_vs_length_multi.R <output_png> [--metadata <file>] <tsv1> <tsv2> ..."
-  )
+if (length(args) < 2) {
+  stop("Usage: plot_quality_vs_length_multi.R <output_png> [--metadata <file>] <tsv1> <tsv2> ...")
 }
 
 output_png <- normalizePath(args[1], mustWork = FALSE)
 args <- args[-1]
 
-metadata <- NULL
 if (length(args) >= 2 && args[1] == "--metadata") {
-  metadata <- readr::read_tsv(args[2], show_col_types = FALSE)
+  # Metadata argument kept for backward compatibility; sample origin is ignored
   args <- args[-c(1, 2)]
-}
-
-map_sample <- NULL
-if (!is.null(metadata)) {
-  fastq_names <- tools::file_path_sans_ext(basename(metadata$fastq))
-  map_sample <- setNames(metadata$experiment, fastq_names)
 }
 
 input_files <- args
@@ -29,36 +20,34 @@ suppressPackageStartupMessages({
   library(readr)
 })
 
-# Extract sample and dataset information from the filename
-parse_file_info <- function(path) {
+parse_dataset <- function(path) {
   fname <- basename(path)
-  dataset <- sub("^.*_(raw|processed|filtered)_stats\\.tsv$", "\\1", fname)
-  sample <- sub("_(raw|processed|filtered)_stats\\.tsv$", "", fname)
-  sample <- sub("^cleaned_", "", sample)
-  sample <- sub("_trimmed$", "", sample)
-  if (!is.null(map_sample) && sample %in% names(map_sample)) {
-    sample <- map_sample[[sample]]
+  if (grepl("_filtered_stats\\.tsv$", fname)) {
+    "filtered"
+  } else {
+    "pre_filter"
   }
-  list(sample = sample, dataset = dataset)
 }
 
-# Read each TSV and add sample and dataset columns based on filename
 data_list <- lapply(input_files, function(f) {
   df <- readr::read_tsv(f, show_col_types = FALSE)
-  info <- parse_file_info(f)
-  df$sample <- info$sample
-  df$dataset <- info$dataset
+  df$dataset <- parse_dataset(f)
   df
 })
 
 df <- do.call(rbind, data_list)
 
-p <- ggplot(df, aes(x = length, y = mean_quality, color = sample, shape = dataset)) +
+p <- ggplot(df, aes(x = length, y = mean_quality, color = dataset)) +
   geom_point(size = 0.05, alpha = 1) +
-  labs(x = "Read length", y = "Mean quality score", color = "Sample", shape = "Dataset") +
+  labs(x = "Read length", y = "Mean quality score", color = "Dataset") +
+  scale_color_manual(
+    values = c(pre_filter = "#1f77b4", filtered = "#ff7f0e"),
+    labels = c(pre_filter = "Pre-filter", filtered = "Filtered")
+  ) +
   theme_minimal()
 
 ggsave(output_png, plot = p, width = 6, height = 4, units = "in")
 
 message("Plot saved to: ", output_png)
 cat(output_png, "\n")
+

--- a/scripts/read_quality_poster.R
+++ b/scripts/read_quality_poster.R
@@ -22,21 +22,29 @@ if (length(tsve) == 0) {
 data_list <- lapply(tsve, function(p) {
   df <- read.table(p, header = TRUE, sep = "\t", stringsAsFactors = FALSE)
   df$mean_quality <- as.numeric(df$mean_quality)
-  df$stage <- tools::file_path_sans_ext(basename(p))
+  fname <- basename(p)
+  if (grepl("_filtered", fname)) {
+    df$dataset <- "filtered"
+  } else {
+    df$dataset <- "pre_filter"
+  }
   df
 })
 
 df_all <- do.call(rbind, data_list)
 
-# Límites fijos para hacer comparables los gráficos entre etapas
+# Límites fijos para hacer comparables los gráficos
 max_length <- 2000
 max_quality <- 45
 
-p <- ggplot(df_all, aes(x = length, y = mean_quality, color = stage)) +
+p <- ggplot(df_all, aes(x = length, y = mean_quality, color = dataset)) +
   geom_point(alpha = 0.5, size = 0.7) +
-  scale_color_brewer(palette = "Dark2") +
+  scale_color_manual(
+    values = c(pre_filter = "#1f77b4", filtered = "#ff7f0e"),
+    labels = c(pre_filter = "Pre-filter", filtered = "Filtered")
+  ) +
   coord_cartesian(xlim = c(0, max_length), ylim = c(0, max_quality)) +
-  labs(x = "Longitud de lectura", y = "Calidad media", color = "Etapa") +
+  labs(x = "Longitud de lectura", y = "Calidad media", color = "Conjunto") +
   theme_minimal()
 
 # Guardar gráfico


### PR DESCRIPTION
## Summary
- Plot pre-filtered vs filtered reads in single-sample quality-length graph
- Aggregate multi-sample quality-length plots by filter status only
- Document that quality-length plots ignore sample origin

## Testing
- `shellcheck scripts/plot_quality_vs_length.R scripts/plot_quality_vs_length_multi.R scripts/read_quality_poster.R`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2fe602ef88321bfd0a2ae2bce1f85