### PR TITLE
feat: make taxon coding optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ El script `scripts/plot_taxon_bar.py` genera un gráfico de barras apiladas con
 la proporción de lecturas por muestra. Puede asignar nombres de experimento a
 las muestras con `--metadata <archivo>` y, opcionalmente, reemplazar los nombres
 por códigos secuenciales (`M1`, `M2`, ...) con `--code-samples`, guardando la
-tabla de equivalencias en `<salida>.sample_map.tsv`. Los taxones se codifican
-siempre como `T1`, `T2`, ... y su correspondencia se escribe en
-`<salida>.taxon_map.tsv`.
+tabla de equivalencias en `<salida>.sample_map.tsv`. De forma predeterminada se
+conservan los nombres de taxones, pero se pueden reemplazar por códigos
+secuenciales (`T1`, `T2`, ...) con `--code-taxa`, guardando la tabla de
+equivalencias en `<salida>.taxon_map.tsv`.
 
 ```bash
 python scripts/plot_taxon_bar.py taxonomy_with_sample.tsv plot.png \
-    --metadata fastq_metadata.tsv --code-samples
+    --metadata fastq_metadata.tsv --code-samples --code-taxa
 ```
 
 ## Entornos Conda

--- a/tests/test_plot_taxon_bar.py
+++ b/tests/test_plot_taxon_bar.py
@@ -120,3 +120,39 @@ def test_fallback_to_clean_fastq(tmp_path):
     map_file = tmp_path / "plot.png.sample_map.tsv"
     content = map_file.read_text().strip().splitlines()
     assert content[1] == "M1\tB"
+
+
+def test_taxon_coding(tmp_path):
+    table = "Sample\tTaxon\tReads\nA\tSp1\t10\nA\tSp2\t5\n"
+    in_file = tmp_path / "taxonomy.tsv"
+    in_file.write_text(table)
+    out_file = tmp_path / "plot.png"
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "plot_taxon_bar.py"
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    subprocess.run(
+        [sys.executable, str(script), str(in_file), str(out_file)],
+        check=True,
+        env=env,
+    )
+
+    map_file = tmp_path / "plot.png.taxon_map.tsv"
+    assert not map_file.exists()
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            str(in_file),
+            str(out_file),
+            "--code-taxa",
+        ],
+        check=True,
+        env=env,
+    )
+
+    content = map_file.read_text().strip().splitlines()
+    assert content[0] == "code\ttaxon"
+    assert content[1] == "T1\tSp1"
+    assert content[2] == "T2\tSp2"


### PR DESCRIPTION
## Summary
- keep taxon names unchanged by default in `plot_taxon_bar.py`
- add optional `--code-taxa` to generate taxon code mapping when needed
- document new flag and cover behavior with tests

## Testing
- `shellcheck scripts/plot_taxon_bar.py` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4bf5db8188321a9cc3cbb8510bc43