### PR TITLE
Rename clustering scripts and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ Active cada entorno solo la primera vez para instalarlo. El script `run_clipon_p
 
 ### Clustering con NGSpeciesID
 ```bash
-./scripts/De2_A2.5_NGSpecies_Clustering.sh <dir_entrada> <dir_salida>
+./scripts/ClipON-Cluster-NGS-Clustering.sh <dir_entrada> <dir_salida>
 ```
 
 ### Unificación de clusters
 ```bash
-./scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh <dir_base> <dir_salida>
+./scripts/ClipON-Cluster-NGS-Unifying.sh <dir_base> <dir_salida>
 ```
 
 ### Generar manifest automáticamente

--- a/scripts/ClipON-Cluster-NGS-Clustering.sh
+++ b/scripts/ClipON-Cluster-NGS-Clustering.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Uso:
-#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./De2_A2.5_NGSpecies_Clustering.sh
-#   o: ./De2_A2.5_NGSpecies_Clustering.sh <dir_entrada> <dir_salida>
+#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./ClipON-Cluster-NGS-Clustering.sh
+#   o: ./ClipON-Cluster-NGS-Clustering.sh <dir_entrada> <dir_salida>
 
 # Directorio que contiene los archivos .fastq y salida configurables
 input_dir="${INPUT_DIR:-$1}"
@@ -34,16 +34,13 @@ for fastq_file in "$input_dir"/*.fastq; do
     # Mostrar mensaje indicando el archivo que se está procesando
     echo "Procesando archivo: $base_name.fastq"
     
-    # Ejecutar el comando para cada archivo .fastq
-    NGSpeciesID --ont --consensus \
-                --m "$m_len" --s "$support" --medaka \
-                --t "$threads" --q "$qual" \
-                --rc_identity_threshold "$rc_id" \
-                --abundance_ratio "$abund_ratio" \
-                --fastq "$fastq_file" --outfolder "$output_dir/$base_name"
-    
-    # Verificar si el comando fue exitoso
-    if [ $? -ne 0 ]; then
+    # Ejecutar el comando para cada archivo .fastq y verificar su éxito
+    if ! NGSpeciesID --ont --consensus \
+        --m "$m_len" --s "$support" --medaka \
+        --t "$threads" --q "$qual" \
+        --rc_identity_threshold "$rc_id" \
+        --abundance_ratio "$abund_ratio" \
+        --fastq "$fastq_file" --outfolder "$output_dir/$base_name"; then
         echo "Error al procesar el archivo: $base_name.fastq. Saliendo."
         exit 1
     fi

--- a/scripts/ClipON-Cluster-NGS-Unifying.sh
+++ b/scripts/ClipON-Cluster-NGS-Unifying.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Uso:
-#   BASE_DIR=/ruta/a/clustered OUTPUT_DIR=/ruta/a/unificado ./De2.5_A3_NGSpecies_Unificar_Clusters.sh
-#   o: ./De2.5_A3_NGSpecies_Unificar_Clusters.sh <dir_base> <dir_salida>
+#   BASE_DIR=/ruta/a/clustered OUTPUT_DIR=/ruta/a/unificado ./ClipON-Cluster-NGS-Unifying.sh
+#   o: ./ClipON-Cluster-NGS-Unifying.sh <dir_base> <dir_salida>
 
 # Directorio base donde están las carpetas y de salida
 BASE_DIR="${BASE_DIR:-$1}"
@@ -20,7 +20,7 @@ mkdir -p "$DIR_SALIDA"
 
 # Archivo maestro que contendrá todas las secuencias con el identificador de experimento
 archivo_maestro="$DIR_SALIDA/consensos_todos.fasta"
-> "$archivo_maestro"
+: > "$archivo_maestro"
 
 # Inicializar una variable para verificar si se han procesado secuencias
 se_agregaron_secuencias=false
@@ -39,7 +39,7 @@ for carpeta in "$BASE_DIR"/*; do
     archivo_salida="$DIR_SALIDA/consensos_${identificador}.fasta"
 
     # Inicializar el archivo individual vacío
-    > "$archivo_salida"
+    : > "$archivo_salida"
 
     # Unificar los archivos .fasta dentro de la carpeta y modificar los IDs
     for fasta in "$carpeta"/consensus_reference_*.fasta; do

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -496,11 +496,11 @@ run_step 4 clipon-ngs "Paso 4: Clustering de NGSpecies" "$CLUSTER_EXTRA_ARGS" \
     M_LEN="$M_LEN" SUPPORT="$SUPPORT" THREADS="$THREADS" \
     QUAL="$QUAL" RC_ID="$RC_ID" ABUND_RATIO="$ABUND_RATIO" \
     INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
-    bash scripts/De2_A2.5_NGSpecies_Clustering.sh
+    bash scripts/ClipON-Cluster-NGS-Clustering.sh
 
 run_step 5 clipon-ngs "Paso 5: Unificación de clusters" "" \
     BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" \
-    bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+    bash scripts/ClipON-Cluster-NGS-Unifying.sh
 
 if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
     echo "No se creó el archivo maestro de consensos. Abortando pipeline."

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -15,6 +15,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
 # Inicializar conda y activar entornos según la etapa
+# shellcheck source=/dev/null
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
 METADATA_FILE=""
@@ -118,8 +119,8 @@ fi
 
 echo "Gráfico de calidad vs longitud: $PLOT_FILE"
 
-run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/De2_A2.5_NGSpecies_Clustering.sh
-run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/De2.5_A3_NGSpecies_Unificar_Clusters.sh
+run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/ClipON-Cluster-NGS-Clustering.sh
+run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/ClipON-Cluster-NGS-Unifying.sh
 
 if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
     echo "No se creó el archivo maestro de consensos. Abortando pipeline."
@@ -141,7 +142,7 @@ if command -v python >/dev/null 2>&1; then
             echo "Fallo en python: revisar dependencias" >> "$WORK_DIR/taxon_plot.log"
             TAX_PLOT_FILE="N/A"
         }
-    read -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
+    read -r -p "¿Abrir el gráfico ahora? [y/N]: " OPEN_TAX_PLOT
     if [[ $OPEN_TAX_PLOT =~ ^[Yy]$ && -f "$TAX_PLOT_FILE" ]]; then
         xdg-open "$TAX_PLOT_FILE"
     else


### PR DESCRIPTION
## Summary
- Rename NGSpecies clustering scripts for consistent naming
- Update pipeline and interactive runners to use new script names
- Refresh README with new command paths

## Testing
- `shellcheck scripts/ClipON-Cluster-NGS-Clustering.sh scripts/ClipON-Cluster-NGS-Unifying.sh scripts/run_clipon_interactive.sh scripts/run_clipon_pipeline.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bf87689e80832198639f1683312d07