### PR TITLE
Rename classification scripts and update runners

### DIFF
--- a/scripts/ClipON-Classif-Export.sh
+++ b/scripts/ClipON-Classif-Export.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Exporta archivos de clasificacion de QIIME2
 # Uso:
-#   ./scripts/De3_A5_Export_Classification.sh <dir_clasificacion>
+#   ./scripts/ClipON-Classif-Export.sh <dir_clasificacion>
 #   o defina la variable CLASS_DIR
 
 class_dir="${CLASS_DIR:-${1-}}"

--- a/scripts/ClipON-Classif-NGS.sh
+++ b/scripts/ClipON-Classif-NGS.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Clasifica consensos con QIIME2 empleando el clasificador BLAST
 # Uso:
-#   ./scripts/De3_A4_Classify_NGS.sh <consensos.fasta> <output_dir> <blast_db.qza> <taxonomy.qza>
+#   ./scripts/ClipON-Classif-NGS.sh <consensos.fasta> <output_dir> <blast_db.qza> <taxonomy.qza>
 # O defina las variables de entorno INPUT_FASTA, OUTPUT_DIR, BLAST_DB y TAXONOMY_DB
 
 input_fasta="${INPUT_FASTA:-${1-}}"

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -421,7 +421,7 @@ classify_reads() {
     fi
     NUM_THREADS="$NUM_THREADS" PERC_ID="$PERC_ID" QUERY_COV="$QUERY_COV" \
     MAX_ACCEPTS="$MAX_ACCEPTS" MIN_CONSENSUS="$MIN_CONSENSUS" \
-    bash scripts/De3_A4_Classify_NGS.sh \
+    bash scripts/ClipON-Classif-NGS.sh \
         "$UNIFIED_DIR/consensos_todos.fasta" \
         "$UNIFIED_DIR" \
         "$BLAST_DB" \
@@ -510,7 +510,7 @@ fi
 run_step 6 clipon-qiime "Paso 6: Clasificación taxonómica" "$CLASSIFY_EXTRA_ARGS" classify_reads
 
 run_step 7 clipon-qiime "Paso 7: Exportación de clasificación" "" \
-    METADATA_FILE="$METADATA_FILE" bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
+    METADATA_FILE="$METADATA_FILE" bash scripts/ClipON-Classif-Export.sh "$UNIFIED_DIR"
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/Results"
 

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -86,7 +86,7 @@ classify_reads() {
         echo "Advertencia: BLAST_DB o TAXONOMY_DB no están definidos. Omitiendo clasificación."
         return 0
     fi
-    bash scripts/De3_A4_Classify_NGS.sh \
+    bash scripts/ClipON-Classif-NGS.sh \
         "$UNIFIED_DIR/consensos_todos.fasta" \
         "$UNIFIED_DIR" \
         "$BLAST_DB" \
@@ -128,7 +128,7 @@ if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
 fi
 
 run_step 6 clipon-qiime classify_reads
-run_step 7 clipon-qiime METADATA_FILE="$METADATA_FILE" bash scripts/De3_A4_Export_Classification.sh "$UNIFIED_DIR"
+run_step 7 clipon-qiime METADATA_FILE="$METADATA_FILE" bash scripts/ClipON-Classif-Export.sh "$UNIFIED_DIR"
 
 echo "Clasificación y exportación finalizadas. Revise $UNIFIED_DIR/Results"
 


### PR DESCRIPTION
## Summary
- rename De3_A4_Classify_NGS.sh to ClipON-Classif-NGS.sh and update usage
- rename De3_A4_Export_Classification.sh to ClipON-Classif-Export.sh and update usage
- adjust run_clipon_interactive.sh and run_clipon_pipeline.sh to call new scripts

## Testing
- `shellcheck -x scripts/ClipON-Classif-NGS.sh scripts/ClipON-Classif-Export.sh scripts/run_clipon_interactive.sh scripts/run_clipon_pipeline.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bf88ed8a208321a26ac692e23498ef