### PR TITLE
Add single clustering method prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Para ejecutarlo se necesita un entorno GNU/Linux o WSL con `bash`. `conda` y [ma
 
 ### Ejecución interactiva
 
-`run_clipon_interactive.sh` es el corazón del proyecto y la forma recomendada de ejecutar ClipON. El asistente, totalmente de código abierto, guía paso a paso a cualquier persona con nociones básicas de la terminal: instala y configura los componentes necesarios, valida los archivos de entrada y permite reanudar ejecuciones previas. También genera automáticamente el manifest que requiere QIIME2. Si se dispone de un archivo de metadata, puede suministrarse de manera opcional con `--metadata <archivo>`. Al final ofrece editar parámetros avanzados de cada etapa.
+`run_clipon_interactive.sh` es el corazón del proyecto y la forma recomendada de ejecutar ClipON. El asistente, totalmente de código abierto, guía paso a paso a cualquier persona con nociones básicas de la terminal: instala y configura los componentes necesarios, valida los archivos de entrada y permite reanudar ejecuciones previas. También genera automáticamente el manifest que requiere QIIME2. Si se dispone de un archivo de metadata, puede suministrarse de manera opcional con `--metadata <archivo>`. Al final ofrece editar parámetros avanzados de cada etapa. Incluye una única pregunta para elegir el método de clustering (NGS = NGSpeciesID o VS = VSearch); actualmente solo la rama NGS está operativa.
 
 ```bash
 ./scripts/run_clipon_interactive.sh

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -215,6 +215,28 @@ while true; do
     break
 done
 
+echo "========================================================="
+echo "Selección de método de clustering"
+echo "========================================================="
+CLUSTER_METHOD="NGS"
+read -rp "¿Qué método desea usar? (NGS = NGSpeciesID / VS = VSearch) [NGS]: " method_choice
+case "${method_choice:-NGS}" in
+    [Nn][Gg][Ss])
+        CLUSTER_METHOD="NGS"
+        ;;
+    [Vv][Ss])
+        CLUSTER_METHOD="VS"
+        ;;
+    *)
+        echo "Opción no reconocida; usando NGS."
+        ;;
+esac
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    echo "El flujo de clustering con VSearch (VS) aún no está disponible en este asistente."
+    echo "Vuelva a ejecutarlo seleccionando NGS para seguir usando NGSpeciesID como hasta ahora."
+    exit 0
+fi
+
 read -rp "¿Desea usar todos los parámetros predeterminados optimizados para COI-FishMock? (s/n) " use_defaults
 if [[ $use_defaults =~ ^[Ss]$ ]]; then
     USE_DEFAULTS=1
@@ -368,6 +390,7 @@ echo "  Base de datos de taxonomía: $TAXONOMY_DB"
 if [ "$MODE" = "resume" ]; then
     echo "  Reanudación desde el paso: $RESUME_CODE"
 fi
+echo " *Método de clustering: $CLUSTER_METHOD (NGSpeciesID)"
 echo " *Recorte de secuencias"
 if [ "$SKIP_TRIM" -eq 1 ]; then
     echo "  Sin recorte"


### PR DESCRIPTION
## Summary
- add a single NGS/VS clustering method prompt to the interactive runner, keeping the NGS flow unchanged and exiting early for VS until implemented
- show the selected method in the configuration summary and document the new prompt in the README

## Testing
- pytest *(fails: ModuleNotFoundError: pandas)*
- shellcheck scripts/run_clipon_interactive.sh *(not run: shellcheck not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69209d9343748321bd3ef1316259053f)