### PR TITLE
Add VSEARCH clustering support to ClipON workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 1. **Procesamiento inicial** – se filtran secuencias corruptas con `SeqKit`.
 2. **Recorte de cebadores** – `Cutadapt` elimina bases al inicio y fin.
 3. **Filtrado de calidad y longitud** – `NanoFilt` descarta lecturas cortas o de baja calidad.
-4. **Clustering** – `NGSpeciesID` agrupa secuencias y genera consensos.
+4. **Clustering** – `NGSpeciesID` (predeterminado) o `VSEARCH` generan
+   consensos a partir de las lecturas filtradas.
 5. **Unificación de clusters** – se combinan los consensos de distintos experimentos.
 6. **Clasificación opcional** – el script `scripts/ClipON-Classif-NGS.sh` usa `qiime feature-classifier classify-consensus-blast` para asignar taxonomía a los consensos unificados.
 7. **Exportación de la clasificación** – `scripts/ClipON-Classif-Export.sh` guarda `taxonomy.qza`, `search_results.qza` y genera `taxonomy_with_sample.tsv` (con columnas *Reads* y *Sample*) en `Results`. Además, crea `reads_per_species.tsv` con el número total de lecturas por especie y muestra.
@@ -21,6 +22,8 @@
 - **ClipON-Cluster**
   - `ClipON-Cluster-NGS-Clustering.sh`
   - `ClipON-Cluster-NGS-Unifying.sh`
+  - `ClipON-Cluster-VSearch.sh`
+  - `ClipON-Cluster-VSearch-Consensus.py`
 - **ClipON-Classif**
   - `ClipON-Classif-NGS.sh`
   - `ClipON-Classif-Export.sh`
@@ -64,7 +67,7 @@ Para ejecutarlo se necesita un entorno GNU/Linux o WSL con `bash`. `conda` y [ma
 
 ### Ejecución interactiva
 
-`run_clipon_interactive.sh` es el corazón del proyecto y la forma recomendada de ejecutar ClipON. El asistente, totalmente de código abierto, guía paso a paso a cualquier persona con nociones básicas de la terminal: instala y configura los componentes necesarios, valida los archivos de entrada y permite reanudar ejecuciones previas. También genera automáticamente el manifest que requiere QIIME2. Si se dispone de un archivo de metadata, puede suministrarse de manera opcional con `--metadata <archivo>`. Al final ofrece editar parámetros avanzados de cada etapa. Incluye una única pregunta para elegir el método de clustering (NGS = NGSpeciesID o VS = VSearch); actualmente solo la rama NGS está operativa.
+`run_clipon_interactive.sh` es el corazón del proyecto y la forma recomendada de ejecutar ClipON. El asistente, totalmente de código abierto, guía paso a paso a cualquier persona con nociones básicas de la terminal: instala y configura los componentes necesarios, valida los archivos de entrada y permite reanudar ejecuciones previas. También genera automáticamente el manifest que requiere QIIME2. Si se dispone de un archivo de metadata, puede suministrarse de manera opcional con `--metadata <archivo>`. Al final ofrece editar parámetros avanzados de cada etapa. Incluye una única pregunta para elegir el método de clustering (NGS = NGSpeciesID o VS = VSearch); la ruta VS importa las lecturas filtradas, ejecuta VSEARCH desde QIIME2 y crea consensos compatibles con el paso de unificación estándar.
 
 ```bash
 ./scripts/run_clipon_interactive.sh
@@ -168,6 +171,18 @@ Active cada entorno solo la primera vez para instalarlo. El script `run_clipon_p
 ### Clustering con NGSpeciesID
 ```bash
 ./scripts/ClipON-Cluster-NGS-Clustering.sh <dir_entrada> <dir_salida>
+```
+
+### Clustering con VSEARCH (QIIME2)
+El script `ClipON-Cluster-VSearch.sh` parte de los FASTQ filtrados
+(`3_filtered`), genera automáticamente el manifest de importación para QIIME2,
+importa las lecturas y ejecuta `vsearch cluster-features-de-novo`.
+Los consensos se guardan en `4_clustered/<muestra>/consensus_reference_*.fasta`
+y en `4_clustered/consensos_todos.fasta`, listos para el paso estándar de
+unificación.
+```bash
+INPUT_DIR=/ruta/a/3_filtered OUTPUT_DIR=/ruta/a/4_clustered \
+  ./scripts/ClipON-Cluster-VSearch.sh
 ```
 
 ### Unificación de clusters

--- a/scripts/ClipON-Cluster-NGS-Unifying.sh
+++ b/scripts/ClipON-Cluster-NGS-Unifying.sh
@@ -44,7 +44,17 @@ for carpeta in "$BASE_DIR"/*; do
     # Unificar los archivos .fasta dentro de la carpeta y modificar los IDs
     for fasta in "$carpeta"/consensus_reference_*.fasta; do
       [ -f "$fasta" ] || continue
-      awk -v id="$identificador" '/^>/ {print $0 "_" id} !/^>/ {print $0}' "$fasta" >> "$archivo_salida"
+      awk -v id="$identificador" '
+        /^>/ {
+          if ($0 ~ "_" id "$") {
+            print $0
+          } else {
+            print $0 "_" id
+          }
+          next
+        }
+        {print $0}
+      ' "$fasta" >> "$archivo_salida"
     done
 
     # Verificar si el archivo individual no está vacío

--- a/scripts/ClipON-Cluster-VSearch-Consensus.py
+++ b/scripts/ClipON-Cluster-VSearch-Consensus.py
@@ -1,0 +1,140 @@
+"""Generate per-sample consensus FASTA files from VSEARCH clustering outputs.
+
+The script expects the exported FASTA file produced by QIIME2 (dna-sequences
+from ``clustered-sequences``) and the corresponding feature table in TSV
+format. For each feature present in a sample, a new FASTA record is emitted
+with the number of supporting reads and the sample identifier in the header.
+
+Output structure (within ``--output-dir``):
+- ``<sample>/consensus_reference_<sample>.fasta`` for each sample present.
+- ``consensos_todos.fasta`` combining all sample-level consensuses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+
+def read_sequences(fasta_path: pathlib.Path) -> dict[str, str]:
+    """Load sequences from a FASTA file into a dictionary."""
+
+    sequences: dict[str, str] = {}
+    current_id: str | None = None
+    parts: list[str] = []
+
+    with fasta_path.open() as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if current_id is not None:
+                    sequences[current_id] = "".join(parts)
+                current_id = line[1:]
+                parts = []
+            else:
+                parts.append(line)
+
+    if current_id is not None:
+        sequences[current_id] = "".join(parts)
+
+    return sequences
+
+
+def read_feature_table(
+    table_path: pathlib.Path,
+) -> tuple[list[str], dict[str, dict[str, int]]]:
+    """Parse a BIOM TSV feature table.
+
+    Returns a tuple with the list of sample IDs and a mapping of feature IDs to
+    counts per sample.
+    """
+
+    samples: list[str] = []
+    counts: dict[str, dict[str, int]] = {}
+    with table_path.open() as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if not line or line.startswith("# Constructed"):
+                continue
+            if line.startswith("#OTU ID"):
+                _, *samples = line.split("\t")
+                continue
+            fields = line.split("\t")
+            feature_id, raw_counts = fields[0], fields[1:]
+            counts[feature_id] = {
+                sample: int(value) if value else 0
+                for sample, value in zip(samples, raw_counts)
+            }
+    return samples, counts
+
+
+def write_consensus_fastas(
+    sequences: dict[str, str],
+    samples: list[str],
+    counts: dict[str, dict[str, int]],
+    output_dir: pathlib.Path,
+) -> None:
+    """Write per-sample and combined consensus FASTA files."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    combined_path = output_dir / "consensos_todos.fasta"
+    combined_handle = combined_path.open("w")
+
+    sample_handles: dict[str, pathlib.Path] = {}
+
+    try:
+        for sample in samples:
+            sample_dir = output_dir / sample
+            sample_dir.mkdir(parents=True, exist_ok=True)
+            sample_path = sample_dir / f"consensus_reference_{sample}.fasta"
+            sample_handles[sample] = sample_path
+
+        open_files = {sample: path.open("w") for sample, path in sample_handles.items()}
+
+        for feature_id, per_sample in counts.items():
+            sequence = sequences.get(feature_id)
+            if sequence is None:
+                continue
+            for sample, count in per_sample.items():
+                if count <= 0:
+                    continue
+                header = f">{feature_id}_total_supporting_reads_{count}_{sample}"
+                record = f"{header}\n{sequence}\n"
+                open_files[sample].write(record)
+                combined_handle.write(record)
+    finally:
+        combined_handle.close()
+        for handle in locals().get("open_files", {}).values():
+            handle.close()
+
+    print(f"Per-sample consensuses in: {output_dir}")
+    print(f"Archivo maestro: {combined_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sequences",
+        required=True,
+        help="Exported dna-sequences.fasta",
+    )
+    parser.add_argument(
+        "--table",
+        required=True,
+        help="BIOM table converted to TSV",
+    )
+    parser.add_argument(
+        "--output-dir", required=True, help="Directory for consensus FASTA files"
+    )
+    args = parser.parse_args()
+
+    sequences = read_sequences(pathlib.Path(args.sequences))
+    samples, counts = read_feature_table(pathlib.Path(args.table))
+
+    write_consensus_fastas(sequences, samples, counts, pathlib.Path(args.output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ClipON-Cluster-VSearch.sh
+++ b/scripts/ClipON-Cluster-VSearch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cluster sequences with QIIME2 + VSEARCH using the ClipON directory layout.
+#
+# Uso:
+#   INPUT_DIR=/ruta/a/fastq OUTPUT_DIR=/ruta/a/salida ./ClipON-Cluster-VSearch.sh
+#   o: ./ClipON-Cluster-VSearch.sh <dir_entrada> <dir_salida>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+input_dir="${INPUT_DIR:-${1-}}"
+output_dir="${OUTPUT_DIR:-${2-}}"
+manifest_path="${MANIFEST_PATH:-$output_dir/manifest.csv}"
+
+# Parámetros de VSEARCH
+VS_IDENTITY="${VS_IDENTITY:-0.98}"
+VS_THREADS="${VS_THREADS:-16}"
+
+if [[ -z "$input_dir" || -z "$output_dir" ]]; then
+    echo "Uso: INPUT_DIR=<dir entrada> OUTPUT_DIR=<dir salida> $0" >&2
+    echo "   o: $0 <dir entrada> <dir salida>" >&2
+    exit 1
+fi
+
+if ! command -v qiime >/dev/null; then
+    echo "No se encontró 'qiime' en el PATH." >&2
+    exit 1
+fi
+
+if ! command -v biom >/dev/null; then
+    echo "No se encontró 'biom' en el PATH." >&2
+    exit 1
+fi
+
+mkdir -p "$output_dir"
+
+# Limpiar consensos previos para evitar contaminar nuevas ejecuciones
+rm -f "$output_dir/consensos_todos.fasta"
+find "$output_dir" -mindepth 1 -maxdepth 1 -type d ! -name export -exec rm -rf {} +
+
+# Generar manifiesto de importación
+bash "$SCRIPT_DIR/generate_manifest.sh" --filtered "$input_dir" >"$manifest_path"
+
+sequences_qza="$output_dir/sequences.qza"
+demux_qzv="$output_dir/demux_summary.qzv"
+derep_table_qza="$output_dir/table_derep.qza"
+derep_seqs_qza="$output_dir/rep_seqs_derep.qza"
+cluster_table_qza="$output_dir/table_clustered.qza"
+cluster_seqs_qza="$output_dir/rep_seqs_clustered.qza"
+export_dir="$output_dir/export"
+
+qiime tools import \
+    --type 'SampleData[SequencesWithQuality]' \
+    --input-path "$manifest_path" \
+    --input-format 'SingleEndFastqManifestPhred33V2' \
+    --output-path "$sequences_qza"
+
+qiime demux summarize \
+    --i-data "$sequences_qza" \
+    --o-visualization "$demux_qzv"
+
+qiime vsearch dereplicate-sequences \
+    --i-sequences "$sequences_qza" \
+    --o-dereplicated-table "$derep_table_qza" \
+    --o-dereplicated-sequences "$derep_seqs_qza" \
+    --verbose
+
+qiime vsearch cluster-features-de-novo \
+    --i-sequences "$derep_seqs_qza" \
+    --i-table "$derep_table_qza" \
+    --p-perc-identity "$VS_IDENTITY" \
+    --p-threads "$VS_THREADS" \
+    --o-clustered-table "$cluster_table_qza" \
+    --o-clustered-sequences "$cluster_seqs_qza" \
+    --verbose
+
+rm -rf "$export_dir"
+mkdir -p "$export_dir"
+
+qiime tools export --input-path "$cluster_seqs_qza" --output-path "$export_dir"
+qiime tools export --input-path "$cluster_table_qza" --output-path "$export_dir"
+
+biom convert \
+    -i "$export_dir/feature-table.biom" \
+    -o "$export_dir/feature-table.tsv" \
+    --to-tsv
+
+python "$SCRIPT_DIR/ClipON-Cluster-VSearch-Consensus.py" \
+    --sequences "$export_dir/dna-sequences.fasta" \
+    --table "$export_dir/feature-table.tsv" \
+    --output-dir "$output_dir"
+
+cat <<EOF
+Clustering VSEARCH finalizado.
+  - Secuencias importadas: $sequences_qza
+  - Resumen demux: $demux_qzv
+  - Tabla de features: $cluster_table_qza
+  - Secuencias clusterizadas: $cluster_seqs_qza
+EOF

--- a/scripts/run_clipon_interactive.sh
+++ b/scripts/run_clipon_interactive.sh
@@ -231,10 +231,14 @@ case "${method_choice:-NGS}" in
         echo "Opción no reconocida; usando NGS."
         ;;
 esac
+
+CLUSTER_CODE="ClipON-Cluster-NGS-Clustering"
+UNIFY_CODE="ClipON-Cluster-NGS-Unifying"
 if [ "$CLUSTER_METHOD" = "VS" ]; then
-    echo "El flujo de clustering con VSearch (VS) aún no está disponible en este asistente."
-    echo "Vuelva a ejecutarlo seleccionando NGS para seguir usando NGSpeciesID como hasta ahora."
-    exit 0
+    CLUSTER_CODE="ClipON-Cluster-VSearch"
+    UNIFY_CODE="ClipON-Cluster-VSearch-Unifying"
+    STEP_CODES[3]="$CLUSTER_CODE"
+    STEP_CODES[4]="$UNIFY_CODE"
 fi
 
 read -rp "¿Desea usar todos los parámetros predeterminados optimizados para COI-FishMock? (s/n) " use_defaults
@@ -243,6 +247,11 @@ if [[ $use_defaults =~ ^[Ss]$ ]]; then
 else
     USE_DEFAULTS=0
 fi
+
+TRIM_EXTRA_ARGS="${TRIM_EXTRA_ARGS:-}"
+FILTER_EXTRA_ARGS="${FILTER_EXTRA_ARGS:-}"
+CLUSTER_EXTRA_ARGS="${CLUSTER_EXTRA_ARGS:-}"
+CLASSIFY_EXTRA_ARGS="${CLASSIFY_EXTRA_ARGS:-}"
 
 if [ "$USE_DEFAULTS" -eq 0 ]; then
     echo "========================================================="
@@ -287,26 +296,39 @@ if [ "$USE_DEFAULTS" -eq 0 ]; then
     fi
 
     if [ "${RESUME_STEP:-1}" -le 4 ]; then
-        print_section "Paso 4 – ClipON-Cluster-NGS-Clustering"
-        DEFAULT_M_LEN=700
-        DEFAULT_SUPPORT=150
-        DEFAULT_THREADS=16
-        DEFAULT_QUAL=10
-        DEFAULT_RC_ID=0.98
-        DEFAULT_ABUND_RATIO=0.01
-        prompt_param M_LEN "  Longitud esperada del consenso (--m)" "$DEFAULT_M_LEN"
-        prompt_param SUPPORT "  Número mínimo de lecturas de soporte (--s)" "$DEFAULT_SUPPORT"
-        prompt_param THREADS "  Número de hilos (--t)" "$DEFAULT_THREADS"
-        prompt_param QUAL "  Calidad mínima (--q)" "$DEFAULT_QUAL"
-        prompt_param RC_ID "  Umbral de identidad de RC (--rc_identity_threshold)" "$DEFAULT_RC_ID"
-        prompt_param ABUND_RATIO "  Proporción mínima de abundancia (--abundance_ratio)" "$DEFAULT_ABUND_RATIO"
+        if [ "$CLUSTER_METHOD" = "VS" ]; then
+            print_section "Paso 4 – ClipON-Cluster-VSearch"
+            DEFAULT_VS_IDENTITY=0.98
+            DEFAULT_VS_THREADS=16
+            prompt_param VS_IDENTITY "  Identidad de clustering (--p-perc-identity)" "$DEFAULT_VS_IDENTITY"
+            prompt_param VS_THREADS "  Número de hilos (--p-threads)" "$DEFAULT_VS_THREADS"
+        else
+            print_section "Paso 4 – ClipON-Cluster-NGS-Clustering"
+            DEFAULT_M_LEN=700
+            DEFAULT_SUPPORT=150
+            DEFAULT_THREADS=16
+            DEFAULT_QUAL=10
+            DEFAULT_RC_ID=0.98
+            DEFAULT_ABUND_RATIO=0.01
+            prompt_param M_LEN "  Longitud esperada del consenso (--m)" "$DEFAULT_M_LEN"
+            prompt_param SUPPORT "  Número mínimo de lecturas de soporte (--s)" "$DEFAULT_SUPPORT"
+            prompt_param THREADS "  Número de hilos (--t)" "$DEFAULT_THREADS"
+            prompt_param QUAL "  Calidad mínima (--q)" "$DEFAULT_QUAL"
+            prompt_param RC_ID "  Umbral de identidad de RC (--rc_identity_threshold)" "$DEFAULT_RC_ID"
+            prompt_param ABUND_RATIO "  Proporción mínima de abundancia (--abundance_ratio)" "$DEFAULT_ABUND_RATIO"
+        fi
     else
-        M_LEN=700
-        SUPPORT=150
-        THREADS=16
-        QUAL=10
-        RC_ID=0.98
-        ABUND_RATIO=0.01
+        if [ "$CLUSTER_METHOD" = "VS" ]; then
+            VS_IDENTITY=0.98
+            VS_THREADS=16
+        else
+            M_LEN=700
+            SUPPORT=150
+            THREADS=16
+            QUAL=10
+            RC_ID=0.98
+            ABUND_RATIO=0.01
+        fi
     fi
 
     if [ "${RESUME_STEP:-1}" -le 6 ]; then
@@ -368,6 +390,8 @@ else
     QUAL=10
     RC_ID=0.98
     ABUND_RATIO=0.01
+    VS_IDENTITY=0.98
+    VS_THREADS=16
     NUM_THREADS=5
     PERC_ID=0.8
     QUERY_COV=0.8
@@ -378,6 +402,8 @@ else
     CLUSTER_EXTRA_ARGS=""
     CLASSIFY_EXTRA_ARGS=""
 fi
+
+resolve_resume
 
 echo "========================================================="
 echo "Resumen de configuración"
@@ -390,7 +416,11 @@ echo "  Base de datos de taxonomía: $TAXONOMY_DB"
 if [ "$MODE" = "resume" ]; then
     echo "  Reanudación desde el paso: $RESUME_CODE"
 fi
-echo " *Método de clustering: $CLUSTER_METHOD (NGSpeciesID)"
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    echo " *Método de clustering: VS (VSEARCH)"
+else
+    echo " *Método de clustering: NGS (NGSpeciesID)"
+fi
 echo " *Recorte de secuencias"
 if [ "$SKIP_TRIM" -eq 1 ]; then
     echo "  Sin recorte"
@@ -398,13 +428,19 @@ else
     echo "  Recorte en -$TRIM_FRONT y +$TRIM_BACK"
 fi
 echo " *Filtro NanoFilt: longitudes $MIN_LEN-$MAX_LEN, calidad mínima $MIN_QUAL"
-echo " *NGSpeciesID:"
-echo "    Longitud esperada del consenso: $M_LEN"
-echo "    Lecturas de soporte: $SUPPORT"
-echo "    Hilos: $THREADS"
-echo "    Calidad mínima: $QUAL"
-echo "    RC identidad: $RC_ID"
-echo "    Proporción mínima de abundancia: $ABUND_RATIO"
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    echo " *VSEARCH:"
+    echo "    Identidad de clustering: $VS_IDENTITY"
+    echo "    Hilos: $VS_THREADS"
+else
+    echo " *NGSpeciesID:"
+    echo "    Longitud esperada del consenso: $M_LEN"
+    echo "    Lecturas de soporte: $SUPPORT"
+    echo "    Hilos: $THREADS"
+    echo "    Calidad mínima: $QUAL"
+    echo "    RC identidad: $RC_ID"
+    echo "    Proporción mínima de abundancia: $ABUND_RATIO"
+fi
 echo " *Clasificación BLAST:"
 echo "    Número de hilos: $NUM_THREADS"
 echo "    Identidad mínima: $PERC_ID"
@@ -436,11 +472,16 @@ CLUSTER_DIR="$WORK_DIR/4_clustered"
 UNIFIED_DIR="$WORK_DIR/5_unified"
 LOG_FILE="$FILTER_DIR/nanofilt.log"
 
+CLUSTER_ENV="clipon-ngs"
+CLUSTER_HEADER="Paso 4 – ClipON-Cluster-NGS-Clustering"
+UNIFY_HEADER="Paso 5 – ClipON-Cluster-NGS-Unifying"
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    CLUSTER_ENV="clipon-qiime"
+    CLUSTER_HEADER="Paso 4 – ClipON-Cluster-VSearch"
+    UNIFY_HEADER="Paso 5 – ClipON-Cluster-VSearch-Unifying"
+fi
+
 # Variables para parámetros avanzados opcionales
-TRIM_EXTRA_ARGS=""
-FILTER_EXTRA_ARGS=""
-CLUSTER_EXTRA_ARGS=""
-CLASSIFY_EXTRA_ARGS=""
 TAX_PLOT_FILE="N/A"
 
 mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR"
@@ -601,13 +642,20 @@ else
     echo "Omitiendo resumen de lecturas y generación del gráfico (RESUME_STEP=${RESUME_STEP:-1} > 3)."
 fi
 
-run_step 4 ClipON-Cluster-NGS-Clustering clipon-ngs "Paso 4 – ClipON-Cluster-NGS-Clustering" "$CLUSTER_EXTRA_ARGS" \
-    M_LEN="$M_LEN" SUPPORT="$SUPPORT" THREADS="$THREADS" \
-    QUAL="$QUAL" RC_ID="$RC_ID" ABUND_RATIO="$ABUND_RATIO" \
-    INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
-    bash scripts/ClipON-Cluster-NGS-Clustering.sh
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    run_step 4 "$CLUSTER_CODE" "$CLUSTER_ENV" "$CLUSTER_HEADER" "$CLUSTER_EXTRA_ARGS" \
+        VS_IDENTITY="$VS_IDENTITY" VS_THREADS="$VS_THREADS" \
+        INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
+        bash scripts/ClipON-Cluster-VSearch.sh
+else
+    run_step 4 "$CLUSTER_CODE" "$CLUSTER_ENV" "$CLUSTER_HEADER" "$CLUSTER_EXTRA_ARGS" \
+        M_LEN="$M_LEN" SUPPORT="$SUPPORT" THREADS="$THREADS" \
+        QUAL="$QUAL" RC_ID="$RC_ID" ABUND_RATIO="$ABUND_RATIO" \
+        INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
+        bash scripts/ClipON-Cluster-NGS-Clustering.sh
+fi
 
-run_step 5 ClipON-Cluster-NGS-Unifying clipon-ngs "Paso 5 – ClipON-Cluster-NGS-Unifying" "" \
+run_step 5 "$UNIFY_CODE" "$CLUSTER_ENV" "$UNIFY_HEADER" "" \
     BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" \
     bash scripts/ClipON-Cluster-NGS-Unifying.sh
 

--- a/scripts/run_clipon_pipeline.sh
+++ b/scripts/run_clipon_pipeline.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Wrapper para ejecutar la cadena completa de procesamiento de ClipON
-# Uso: ./run_clipon_pipeline.sh [--metadata <archivo>] <dir_fastq_entrada> <dir_trabajo>
+# Uso: ./run_clipon_pipeline.sh [--metadata <archivo>] [--cluster-method NGS|VS] \
+#   <dir_fastq_entrada> <dir_trabajo>
 # El directorio de trabajo contendrá subcarpetas para cada etapa
 
 # Para un gráfico avanzado de la calidad de lectura combine los TSV generados en cada etapa (ClipON-Prep-CollectReadStats.py):
@@ -19,10 +20,15 @@ cd "$ROOT_DIR"
 source "$(conda info --base)/etc/profile.d/conda.sh"
 
 METADATA_FILE=""
+CLUSTER_METHOD="${CLUSTER_METHOD:-NGS}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --metadata)
             METADATA_FILE="${2:-}"
+            shift 2
+            ;;
+        --cluster-method)
+            CLUSTER_METHOD="${2:-NGS}"
             shift 2
             ;;
         *)
@@ -32,9 +38,22 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ "$#" -ne 2 ]; then
-    echo "Uso: $0 [--metadata <archivo>] <dir_fastq_entrada> <dir_trabajo>"
+    echo "Uso: $0 [--metadata <archivo>] [--cluster-method NGS|VS] <dir_fastq_entrada> <dir_trabajo>"
     exit 1
 fi
+
+case "${CLUSTER_METHOD^^}" in
+    NGS)
+        CLUSTER_METHOD="NGS"
+        ;;
+    VS)
+        CLUSTER_METHOD="VS"
+        ;;
+    *)
+        echo "Método de clustering no reconocido: $CLUSTER_METHOD (use NGS o VS)" >&2
+        exit 1
+        ;;
+esac
 
 INPUT_DIR="${1%/}"
 WORK_DIR="${2%/}"
@@ -44,6 +63,8 @@ SKIP_TRIM="${SKIP_TRIM:-0}"
 TRIM_FRONT="${TRIM_FRONT:-30}"
 TRIM_BACK="${TRIM_BACK:-30}"
 RESUME_STEP="${RESUME_STEP:-1}"
+VS_IDENTITY="${VS_IDENTITY:-0.98}"
+VS_THREADS="${VS_THREADS:-16}"
 
 # Definir subdirectorios
 PROCESSED_DIR="$WORK_DIR/1_processed"
@@ -54,6 +75,11 @@ UNIFIED_DIR="$WORK_DIR/5_unified"
 LOG_FILE="$FILTER_DIR/nanofilt.log"
 
 mkdir -p "$PROCESSED_DIR" "$TRIM_DIR" "$FILTER_DIR" "$CLUSTER_DIR" "$UNIFIED_DIR"
+
+CLUSTER_ENV="clipon-ngs"
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    CLUSTER_ENV="clipon-qiime"
+fi
 
 run_step() {
     local step="$1"
@@ -119,8 +145,15 @@ fi
 
 echo "Gráfico de calidad vs longitud: $PLOT_FILE"
 
-run_step 4 clipon-ngs INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" bash scripts/ClipON-Cluster-NGS-Clustering.sh
-run_step 5 clipon-ngs BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/ClipON-Cluster-NGS-Unifying.sh
+if [ "$CLUSTER_METHOD" = "VS" ]; then
+    run_step 4 "$CLUSTER_ENV" INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
+        VS_IDENTITY="$VS_IDENTITY" VS_THREADS="$VS_THREADS" \
+        bash scripts/ClipON-Cluster-VSearch.sh
+else
+    run_step 4 "$CLUSTER_ENV" INPUT_DIR="$FILTER_DIR" OUTPUT_DIR="$CLUSTER_DIR" \
+        bash scripts/ClipON-Cluster-NGS-Clustering.sh
+fi
+run_step 5 "$CLUSTER_ENV" BASE_DIR="$CLUSTER_DIR" OUTPUT_DIR="$UNIFIED_DIR" bash scripts/ClipON-Cluster-NGS-Unifying.sh
 
 if [ ! -s "$UNIFIED_DIR/consensos_todos.fasta" ]; then
     echo "No se creó el archivo maestro de consensos. Abortando pipeline."


### PR DESCRIPTION
## Summary
- add a QIIME2+VSEARCH clustering script plus consensus generator that produce per-sample outputs compatible with the existing unification step
- enable choosing the VSEARCH path in the interactive and batch pipelines with dedicated parameters and refreshed documentation
- improve cluster unification so sample identifiers are not duplicated when headers already include them

## Testing
- pytest *(fails: missing pandas for plotting tests)*
- shellcheck *(not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920a9a2e25883219b0d399e3ed50004)