### PR TITLE
Write manifests as TSV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,17 +191,20 @@ INPUT_DIR=/ruta/a/3_filtered OUTPUT_DIR=/ruta/a/4_clustered \
 ```
 
 ### Generar manifest automáticamente
-El archivo `manifest.csv` requerido por QIIME2 puede crearse con:
+El archivo `manifest.tsv` requerido por QIIME2 puede crearse con:
 
 ```bash
-./scripts/generate_manifest.sh --workdir <dir_trabajo> filtered > manifest.csv
+./scripts/generate_manifest.sh --workdir <dir_trabajo> filtered --output manifest.tsv
 ```
 
 También puede generarse a partir de los consensos unificados:
 
 ```bash
-./scripts/generate_manifest.sh --workdir <dir_trabajo> unified > manifest.csv
+./scripts/generate_manifest.sh --workdir <dir_trabajo> unified --output manifest.tsv
 ```
+
+El script escribe el manifest con separadores de tabulación y normaliza los saltos
+de línea al formato Unix (usa `dos2unix` si está disponible).
 
 ### Clasificación con QIIME2
 ```bash

--- a/scripts/ClipON-Cluster-VSearch.sh
+++ b/scripts/ClipON-Cluster-VSearch.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 input_dir="${INPUT_DIR:-${1-}}"
 output_dir="${OUTPUT_DIR:-${2-}}"
-manifest_path="${MANIFEST_PATH:-$output_dir/manifest.csv}"
+manifest_path="${MANIFEST_PATH:-$output_dir/manifest.tsv}"
 
 # Parámetros de VSEARCH
 VS_IDENTITY="${VS_IDENTITY:-0.98}"
@@ -40,9 +40,9 @@ rm -f "$output_dir/consensos_todos.fasta"
 find "$output_dir" -mindepth 1 -maxdepth 1 -type d ! -name export -exec rm -rf {} +
 
 # Generar manifiesto de importación
-bash "$SCRIPT_DIR/generate_manifest.sh" --filtered "$input_dir" >"$manifest_path"
-# Normalizar saltos de línea para evitar errores de importación en QIIME2
-sed -i 's/\r$//' "$manifest_path"
+bash "$SCRIPT_DIR/generate_manifest.sh" \
+    --filtered "$input_dir" \
+    --output "$manifest_path"
 
 sequences_qza="$output_dir/sequences.qza"
 demux_qzv="$output_dir/demux_summary.qzv"

--- a/scripts/generate_manifest.sh
+++ b/scripts/generate_manifest.sh
@@ -3,30 +3,56 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'
-Usage: $0 (--filtered DIR | --unified DIR | --workdir DIR STEP)
+Usage: $0 [--output FILE] (--filtered DIR | --unified DIR | --workdir DIR STEP)
 
 Generate a QIIME2 manifest from the ClipON pipeline outputs.
 
-  --filtered DIR      Directory containing filtered FASTQ files.
-  --unified DIR       Directory produced by the unification step.
-  --workdir DIR STEP  Use DIR/3_filtered or DIR/5_unified depending on STEP
-                      (filtered|unified).
+  --filtered DIR       Directory containing filtered FASTQ files.
+  --unified DIR        Directory produced by the unification step.
+  --workdir DIR STEP   Use DIR/3_filtered or DIR/5_unified depending on STEP
+                       (filtered|unified).
+  -o, --output FILE    Write the manifest TSV to FILE (with Unix line endings).
 EOF
     exit 1
 }
 
-if [ "$#" -lt 2 ]; then
+mode=""
+input_dir=""
+output_file=""
+workdir_step=""
+
+while (($#)); do
+    case "$1" in
+        --filtered|--unified)
+            mode="$1"
+            input_dir="${2-}"
+            shift 2
+            ;;
+        --workdir)
+            mode="$1"
+            input_dir="${2-}"
+            workdir_step="${3-}"
+            shift 3
+            ;;
+        -o|--output)
+            output_file="${2-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$mode" || -z "$input_dir" ]]; then
     usage
 fi
 
-mode="$1"
-input_dir="$2"
-
 if [ "$mode" = "--workdir" ]; then
-    if [ "$#" -ne 3 ]; then
-        usage
-    fi
-    case "$3" in
+    case "$workdir_step" in
         filtered)
             mode="--filtered"
             input_dir="$input_dir/3_filtered"
@@ -46,33 +72,55 @@ if [ ! -d "$input_dir" ]; then
     exit 1
 fi
 
-# Print CSV header
-echo "sample-id,absolute-filepath,direction"
+write_manifest() {
+    local dest="$1"
 
-case "$mode" in
-    --filtered)
-        shopt -s nullglob
-        for f in "$input_dir"/*.fastq "$input_dir"/*.fq; do
-            [ -f "$f" ] || continue
-            sample=$(basename "$f")
-            sample=${sample%.fastq}
-            sample=${sample%.fq}
-            abs=$(readlink -f "$f")
-            echo "${sample},${abs},forward"
-        done
-        ;;
-    --unified)
-        shopt -s nullglob
-        for f in "$input_dir"/consensos_*.fasta; do
-            [ -f "$f" ] || continue
-            base=$(basename "$f")
-            sample=${base#consensos_}
-            sample=${sample%.fasta}
-            abs=$(readlink -f "$f")
-            echo "${sample},${abs},forward"
-        done
-        ;;
-    *)
-        usage
-        ;;
-esac
+    printf 'sample-id\tabsolute-filepath\tdirection\n' >"$dest"
+
+    case "$mode" in
+        --filtered)
+            shopt -s nullglob
+            for f in "$input_dir"/*.fastq "$input_dir"/*.fq; do
+                [ -f "$f" ] || continue
+                sample=$(basename "$f")
+                sample=${sample%.fastq}
+                sample=${sample%.fq}
+                abs=$(readlink -f "$f")
+                printf '%s\t%s\t%s\n' "$sample" "$abs" "forward" >>"$dest"
+            done
+            ;;
+        --unified)
+            shopt -s nullglob
+            for f in "$input_dir"/consensos_*.fasta; do
+                [ -f "$f" ] || continue
+                base=$(basename "$f")
+                sample=${base#consensos_}
+                sample=${sample%.fasta}
+                abs=$(readlink -f "$f")
+                printf '%s\t%s\t%s\n' "$sample" "$abs" "forward" >>"$dest"
+            done
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+if [ -n "$output_file" ]; then
+    tmp_file="$(mktemp)"
+    trap 'rm -f "$tmp_file"' EXIT
+
+    write_manifest "$tmp_file"
+
+    if command -v dos2unix >/dev/null; then
+        dos2unix "$tmp_file" >/dev/null 2>&1
+    else
+        sed -i 's/\r$//' "$tmp_file"
+    fi
+
+    mkdir -p "$(dirname "$output_file")"
+    mv "$tmp_file" "$output_file"
+    trap - EXIT
+else
+    write_manifest /dev/stdout
+fi


### PR DESCRIPTION
## Summary
- update `generate_manifest.sh` to write tab-separated manifests and note TSV output in help text
- adjust the VSEARCH clustering helper to expect a `.tsv` manifest
- refresh README instructions to reference TSV manifests and tab-separated output

## Testing
- shellcheck scripts/generate_manifest.sh scripts/ClipON-Cluster-VSearch.sh *(not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920b3f7428083218ddc0d6140ad7cdc)