### PR TITLE
Handle float counts in feature table parsing

### DIFF
--- a/scripts/ClipON-Cluster-VSearch-Consensus.py
+++ b/scripts/ClipON-Cluster-VSearch-Consensus.py
@@ -63,10 +63,14 @@ def read_feature_table(
                 continue
             fields = line.split("\t")
             feature_id, raw_counts = fields[0], fields[1:]
-            counts[feature_id] = {
-                sample: int(value) if value else 0
-                for sample, value in zip(samples, raw_counts)
-            }
+            counts[feature_id] = {}
+            for sample, value in zip(samples, raw_counts):
+                if not value:
+                    counts[feature_id][sample] = 0
+                    continue
+
+                numeric_value = int(float(value))
+                counts[feature_id][sample] = numeric_value
     return samples, counts
 
 


### PR DESCRIPTION
## Summary
- safely parse feature table counts that are represented as floating point strings
- preserve zero counts when values are empty

## Testing
- pytest (fails: missing pandas dependency in test environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920fd160900832192831a1b3f38d021)