### PR TITLE
Remove stray text from clustering script

### DIFF
--- a/scripts/ClipON-Cluster-VSearch-Consensus.py
+++ b/scripts/ClipON-Cluster-VSearch-Consensus.py
@@ -68,8 +68,6 @@ def read_feature_table(
                 if not value:
                     counts[feature_id][sample] = 0
                     continue
-
-                    codex/fix-valueerror-in-read_feature_table-00kx2w
                 # Algunos exportes de BIOM representan los conteos como "1.0" en lugar
                 # de enteros puros. Convertimos primero a float y luego redondeamos a
                 # entero para evitar errores de conversión (p. ej., ValueError por


### PR DESCRIPTION
## Summary
- remove stray text that was causing a SyntaxError in `ClipON-Cluster-VSearch-Consensus.py`

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69211250c6b88321a522829871cacb25)